### PR TITLE
feat: M5 MCP OAuth 2.1 — Claude Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ next-env.d.ts
 # Config file with API keys - NEVER COMMIT
 config.json
 **/config.json
+.claude/worktrees/

--- a/apps/backend/alembic/versions/3f69006cde50_add_oauth_clients_table.py
+++ b/apps/backend/alembic/versions/3f69006cde50_add_oauth_clients_table.py
@@ -1,0 +1,52 @@
+"""add oauth_clients table
+
+Revision ID: 3f69006cde50
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-03 16:48:16.433014
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3f69006cde50'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('oauth_clients',
+    sa.Column('client_id', sa.String(length=255), nullable=False),
+    sa.Column('client_name', sa.String(length=255), nullable=True),
+    sa.Column('redirect_uris', sa.JSON(), nullable=False),
+    sa.Column('grant_types', sa.JSON(), nullable=False),
+    sa.Column('response_types', sa.JSON(), nullable=False),
+    sa.Column('token_endpoint_auth_method', sa.String(length=50), nullable=False),
+    sa.Column('is_active', sa.Boolean(), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('(CURRENT_TIMESTAMP)'), nullable=False),
+    sa.PrimaryKeyConstraint('client_id')
+    )
+    # Seed the first-party client
+    op.execute(
+        sa.text(
+            "INSERT INTO oauth_clients (client_id, client_name, redirect_uris, grant_types, response_types, token_endpoint_auth_method, is_active) "
+            "VALUES (:cid, :name, :uris, :grants, :types, :method, 1)"
+        ).bindparams(
+            cid="resume-matcher-web",
+            name="Resume Matcher Web",
+            uris='["http://localhost:3000/callback", "http://127.0.0.1:3000/callback"]',
+            grants='["authorization_code", "refresh_token"]',
+            types='["code"]',
+            method="none",
+        )
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('oauth_clients')

--- a/apps/backend/alembic/versions/a1b2c3d4e5f6_make_user_id_not_null.py
+++ b/apps/backend/alembic/versions/a1b2c3d4e5f6_make_user_id_not_null.py
@@ -1,0 +1,60 @@
+"""make_user_id_not_null_add_master_index
+
+Revision ID: a1b2c3d4e5f6
+Revises: 42511b93573f
+Create Date: 2026-04-03 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '42511b93573f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Make user_id NOT NULL on resumes, jobs, improvements; add per-user master index."""
+    # Delete all rows — no production data exists yet.
+    op.execute(sa.text("DELETE FROM improvements"))
+    op.execute(sa.text("DELETE FROM jobs"))
+    op.execute(sa.text("DELETE FROM resumes"))
+
+    # Make user_id NOT NULL using batch mode (required for SQLite).
+    with op.batch_alter_table("resumes") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=False)
+
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=False)
+
+    with op.batch_alter_table("improvements") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=False)
+
+    # Partial unique index: one master resume per user.
+    op.create_index(
+        "ix_resumes_user_master",
+        "resumes",
+        ["user_id"],
+        unique=True,
+        sqlite_where=sa.text("is_master = 1"),
+        postgresql_where=sa.text("is_master = true"),
+    )
+
+
+def downgrade() -> None:
+    """Revert user_id to nullable, drop master index."""
+    op.drop_index("ix_resumes_user_master", table_name="resumes")
+
+    with op.batch_alter_table("improvements") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=True)
+
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=True)
+
+    with op.batch_alter_table("resumes") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=True)

--- a/apps/backend/alembic/versions/a1b2c3d4e5f6_make_user_id_not_null.py
+++ b/apps/backend/alembic/versions/a1b2c3d4e5f6_make_user_id_not_null.py
@@ -20,10 +20,10 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Make user_id NOT NULL on resumes, jobs, improvements; add per-user master index."""
-    # Delete all rows — no production data exists yet.
-    op.execute(sa.text("DELETE FROM improvements"))
-    op.execute(sa.text("DELETE FROM jobs"))
-    op.execute(sa.text("DELETE FROM resumes"))
+    # Delete only orphaned rows (NULL user_id) -- safe for populated databases
+    op.execute(sa.text("DELETE FROM improvements WHERE user_id IS NULL"))
+    op.execute(sa.text("DELETE FROM jobs WHERE user_id IS NULL"))
+    op.execute(sa.text("DELETE FROM resumes WHERE user_id IS NULL"))
 
     # Make user_id NOT NULL using batch mode (required for SQLite).
     with op.batch_alter_table("resumes") as batch_op:

--- a/apps/backend/app/auth/dependencies.py
+++ b/apps/backend/app/auth/dependencies.py
@@ -4,7 +4,6 @@ from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.auth.jwt import verify_access_token
-from app.config import settings
 from app.database import db
 
 _bearer_scheme = HTTPBearer(auto_error=False)
@@ -22,9 +21,7 @@ async def get_current_user(
         )
 
     try:
-        claims = verify_access_token(
-            credentials.credentials, secret=settings.effective_jwt_secret
-        )
+        claims = verify_access_token(credentials.credentials)
     except ValueError:
         raise HTTPException(
             status_code=401,
@@ -49,9 +46,7 @@ async def get_optional_user(
     if not credentials:
         return None
     try:
-        claims = verify_access_token(
-            credentials.credentials, secret=settings.effective_jwt_secret
-        )
+        claims = verify_access_token(credentials.credentials)
     except ValueError:
         return None
     return await db.get_user_by_id(claims["sub"])

--- a/apps/backend/app/auth/google.py
+++ b/apps/backend/app/auth/google.py
@@ -116,7 +116,6 @@ def validate_id_token_claims(
     if claims.get("nonce") != expected_nonce:
         raise ValueError("Nonce mismatch")
     return claims
-<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/auth/google.py
+++ b/apps/backend/app/auth/google.py
@@ -116,6 +116,7 @@ def validate_id_token_claims(
     if claims.get("nonce") != expected_nonce:
         raise ValueError("Nonce mismatch")
     return claims
+<<<<<<< HEAD
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/app/auth/jwt.py
+++ b/apps/backend/app/auth/jwt.py
@@ -33,7 +33,7 @@ def verify_access_token(token: str) -> dict:
     """Verify and decode an RS256 JWT access token. Raises ValueError on failure."""
     key = get_public_key()
     try:
-        decoded = jwt.decode(token, key)
+        decoded = jwt.decode(token, key, algorithms=["RS256"])
     except Exception as e:
         raise ValueError(f"Token invalid: {e}") from e
 

--- a/apps/backend/app/auth/jwt.py
+++ b/apps/backend/app/auth/jwt.py
@@ -1,23 +1,22 @@
-"""JWT access token operations using joserfc."""
+"""JWT access token operations using joserfc (RS256)."""
 
 import time
 
 from joserfc import jwt
-from joserfc.jwk import OctKey
 
 from app.auth.constants import ACCESS_TOKEN_EXPIRE_MINUTES
+from app.auth.keys import get_kid, get_private_key, get_public_key
 
-_ALGORITHM = "HS256"
+_ALGORITHM = "RS256"
 _ISSUER = "resume-matcher"
 
 
 def create_access_token(
     user_id: str,
     email: str,
-    secret: str,
     expires_minutes: int = ACCESS_TOKEN_EXPIRE_MINUTES,
 ) -> str:
-    """Create a signed JWT access token."""
+    """Create an RS256-signed JWT access token."""
     now = int(time.time())
     claims = {
         "sub": user_id,
@@ -26,13 +25,13 @@ def create_access_token(
         "iat": now,
         "exp": now + (expires_minutes * 60),
     }
-    key = OctKey.import_key(secret)
-    return jwt.encode({"alg": _ALGORITHM}, claims, key)
+    key = get_private_key()
+    return jwt.encode({"alg": _ALGORITHM, "kid": get_kid()}, claims, key)
 
 
-def verify_access_token(token: str, secret: str) -> dict:
-    """Verify and decode a JWT access token. Raises ValueError on failure."""
-    key = OctKey.import_key(secret)
+def verify_access_token(token: str) -> dict:
+    """Verify and decode an RS256 JWT access token. Raises ValueError on failure."""
+    key = get_public_key()
     try:
         decoded = jwt.decode(token, key)
     except Exception as e:

--- a/apps/backend/app/auth/keys.py
+++ b/apps/backend/app/auth/keys.py
@@ -1,0 +1,102 @@
+"""RSA key management for RS256 JWT signing."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from joserfc.jwk import RSAKey
+
+logger = logging.getLogger(__name__)
+
+_cached_keys: tuple[RSAKey, RSAKey, str] | None = None
+
+
+def compute_kid(public_key: RSAKey) -> str:
+    """Compute JWK Thumbprint (RFC 7638) as key ID."""
+    return public_key.thumbprint()
+
+
+def load_rsa_keys(
+    pem_data: str | None = None,
+    key_file: str | None = None,
+) -> None:
+    """Load or generate RSA key pair. Call once at startup.
+
+    Priority: pem_data > key_file > auto-generate (saves to key_file if given).
+    """
+    global _cached_keys  # noqa: PLW0603
+    if _cached_keys is not None:
+        return
+
+    private_key: RSAKey
+    if pem_data:
+        logger.info("Loading RSA key from PEM data")
+        try:
+            private_key = RSAKey.import_key(pem_data)
+        except Exception as e:
+            raise ValueError(f"Failed to load RSA key from PEM data: {e}") from e
+    elif key_file:
+        path = Path(key_file)
+        if path.exists():
+            logger.info("Loading RSA key from file: %s", path)
+            try:
+                private_key = RSAKey.import_key(path.read_text())
+            except Exception as e:
+                raise ValueError(f"Failed to load RSA key from {path}: {e}") from e
+        else:
+            logger.info("Generating RSA key and saving to: %s", path)
+            private_key = RSAKey.generate_key(2048)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(private_key.as_pem(private=True))
+            path.chmod(0o600)
+    else:
+        logger.info("Auto-generating RSA key pair (in-memory only)")
+        private_key = RSAKey.generate_key(2048)
+
+    pub_dict = private_key.as_dict(private=False)
+    public_key = RSAKey.import_key(pub_dict)
+    kid = compute_kid(public_key)
+    _cached_keys = (private_key, public_key, kid)
+    logger.info("RSA keys loaded — kid=%s", kid)
+
+
+def get_private_key() -> RSAKey:
+    """Return cached RSA private key. Raises RuntimeError if not loaded."""
+    if _cached_keys is None:
+        raise RuntimeError("RSA keys not loaded — call load_rsa_keys() first")
+    return _cached_keys[0]
+
+
+def get_public_key() -> RSAKey:
+    """Return cached RSA public key. Raises RuntimeError if not loaded."""
+    if _cached_keys is None:
+        raise RuntimeError("RSA keys not loaded — call load_rsa_keys() first")
+    return _cached_keys[1]
+
+
+def get_kid() -> str:
+    """Return JWK Thumbprint (kid). Raises RuntimeError if not loaded."""
+    if _cached_keys is None:
+        raise RuntimeError("RSA keys not loaded — call load_rsa_keys() first")
+    return _cached_keys[2]
+
+
+def get_jwks() -> dict:
+    """Return public key in JWKS format (RFC 7517). No private components."""
+    pub = get_public_key()
+    pub_dict = pub.as_dict(private=False)
+    return {"keys": [{
+        "kty": pub_dict["kty"],
+        "use": "sig",
+        "alg": "RS256",
+        "kid": get_kid(),
+        "n": pub_dict["n"],
+        "e": pub_dict["e"],
+    }]}
+
+
+def reset_keys() -> None:
+    """Clear cached keys (testing only)."""
+    global _cached_keys  # noqa: PLW0603
+    _cached_keys = None

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -165,6 +165,17 @@ class Settings(BaseSettings):
     google_client_id: str = ""
     google_client_secret: str = ""
 
+    # RSA Key Configuration (for RS256 JWT signing)
+    rsa_private_key_pem: str = ""
+    rsa_key_file: str = ""
+
+    @property
+    def effective_rsa_key_file(self) -> Path:
+        """Path to RSA private key file."""
+        if self.rsa_key_file:
+            return Path(self.rsa_key_file)
+        return self.data_dir / "jwt_rsa_private.pem"
+
     @property
     def effective_jwt_secret(self) -> str:
         """JWT secret key -- required for auth endpoints."""

--- a/apps/backend/app/database.py
+++ b/apps/backend/app/database.py
@@ -10,7 +10,7 @@ from sqlalchemy import delete, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
-from app.models import AuthorizationCode, Base, Improvement, Job, OAuthAccount, RefreshToken, Resume, User
+from app.models import AuthorizationCode, Base, Improvement, Job, OAuthAccount, OAuthClient, RefreshToken, Resume, User
 
 logger = logging.getLogger(__name__)
 
@@ -348,6 +348,52 @@ class Database:
             "provider_email": o.provider_email,
             "created_at": o.created_at.isoformat() if o.created_at else None,
         }
+
+    # -- OAuth client operations -----------------------------------------------
+
+    @staticmethod
+    def _oauth_client_to_dict(c: OAuthClient) -> dict[str, Any]:
+        return {
+            "client_id": c.client_id,
+            "client_name": c.client_name,
+            "redirect_uris": c.redirect_uris or [],
+            "grant_types": c.grant_types or ["authorization_code"],
+            "response_types": c.response_types or ["code"],
+            "token_endpoint_auth_method": c.token_endpoint_auth_method or "none",
+            "is_active": c.is_active,
+            "created_at": c.created_at.isoformat() if c.created_at else None,
+        }
+
+    async def create_oauth_client(
+        self,
+        client_name: str | None = None,
+        redirect_uris: list[str] | None = None,
+        grant_types: list[str] | None = None,
+        response_types: list[str] | None = None,
+        token_endpoint_auth_method: str = "none",
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        client = OAuthClient(
+            client_id=client_id or str(uuid4()),
+            client_name=client_name,
+            redirect_uris=redirect_uris or [],
+            grant_types=grant_types or ["authorization_code"],
+            response_types=response_types or ["code"],
+            token_endpoint_auth_method=token_endpoint_auth_method,
+        )
+        async with self._session() as session:
+            session.add(client)
+            await session.commit()
+            await session.refresh(client)
+            return self._oauth_client_to_dict(client)
+
+    async def get_oauth_client(self, client_id: str) -> dict[str, Any] | None:
+        async with self._session() as session:
+            result = await session.execute(
+                select(OAuthClient).where(OAuthClient.client_id == client_id)
+            )
+            row = result.scalar_one_or_none()
+            return self._oauth_client_to_dict(row) if row else None
 
     # -- OAuth account operations -----------------------------------------------
 

--- a/apps/backend/app/database.py
+++ b/apps/backend/app/database.py
@@ -141,6 +141,7 @@ class Database:
     async def create_resume(
         self,
         content: str,
+        user_id: str,
         content_type: str = "md",
         filename: str | None = None,
         is_master: bool = False,
@@ -154,6 +155,7 @@ class Database:
     ) -> dict[str, Any]:
         resume = Resume(
             resume_id=str(uuid4()),
+            user_id=user_id,
             content=content,
             content_type=content_type,
             filename=filename,
@@ -175,6 +177,7 @@ class Database:
     async def create_resume_atomic_master(
         self,
         content: str,
+        user_id: str,
         content_type: str = "md",
         filename: str | None = None,
         processed_data: dict[str, Any] | None = None,
@@ -184,96 +187,113 @@ class Database:
         original_markdown: str | None = None,
     ) -> dict[str, Any]:
         async with self._master_resume_lock:
-            current_master = await self.get_master_resume()
+            current_master = await self.get_master_resume(user_id)
             is_master = current_master is None
             if current_master and current_master.get("processing_status") in ("failed", "processing"):
-                await self.update_resume(current_master["resume_id"], {"is_master": False})
+                await self.update_resume(current_master["resume_id"], user_id, {"is_master": False})
                 is_master = True
             return await self.create_resume(
-                content=content, content_type=content_type, filename=filename,
+                content=content, user_id=user_id, content_type=content_type, filename=filename,
                 is_master=is_master, processed_data=processed_data,
                 processing_status=processing_status, cover_letter=cover_letter,
                 outreach_message=outreach_message, original_markdown=original_markdown,
             )
 
-    async def get_resume(self, resume_id: str) -> dict[str, Any] | None:
+    async def get_resume(self, resume_id: str, user_id: str) -> dict[str, Any] | None:
         async with self._session() as session:
-            result = await session.execute(select(Resume).where(Resume.resume_id == resume_id))
+            result = await session.execute(
+                select(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id)
+            )
             row = result.scalar_one_or_none()
             return self._resume_to_dict(row) if row else None
 
-    async def get_master_resume(self) -> dict[str, Any] | None:
+    async def get_master_resume(self, user_id: str) -> dict[str, Any] | None:
         async with self._session() as session:
-            result = await session.execute(select(Resume).where(Resume.is_master == True))
+            result = await session.execute(
+                select(Resume).where(Resume.is_master == True, Resume.user_id == user_id)
+            )
             row = result.scalar_one_or_none()
             return self._resume_to_dict(row) if row else None
 
-    async def update_resume(self, resume_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+    async def update_resume(self, resume_id: str, user_id: str, updates: dict[str, Any]) -> dict[str, Any]:
         updates["updated_at"] = datetime.now(timezone.utc)
         async with self._session() as session:
             result = await session.execute(
-                update(Resume).where(Resume.resume_id == resume_id).values(**updates)
+                update(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id).values(**updates)
             )
             if result.rowcount == 0:
                 raise ValueError(f"Resume not found: {resume_id}")
             await session.commit()
-        return await self.get_resume(resume_id)
+        return await self.get_resume(resume_id, user_id)
 
-    async def delete_resume(self, resume_id: str) -> bool:
+    async def delete_resume(self, resume_id: str, user_id: str) -> bool:
         async with self._session() as session:
-            result = await session.execute(delete(Resume).where(Resume.resume_id == resume_id))
+            result = await session.execute(
+                delete(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id)
+            )
             await session.commit()
             return result.rowcount > 0
 
-    async def list_resumes(self) -> list[dict[str, Any]]:
+    async def list_resumes(self, user_id: str) -> list[dict[str, Any]]:
         async with self._session() as session:
-            result = await session.execute(select(Resume))
+            result = await session.execute(select(Resume).where(Resume.user_id == user_id))
             return [self._resume_to_dict(r) for r in result.scalars().all()]
 
-    async def set_master_resume(self, resume_id: str) -> bool:
+    async def set_master_resume(self, resume_id: str, user_id: str) -> bool:
         async with self._session() as session:
-            target = await session.execute(select(Resume).where(Resume.resume_id == resume_id))
+            target = await session.execute(
+                select(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id)
+            )
             if not target.scalar_one_or_none():
                 logger.warning("Cannot set master: resume %s not found", resume_id)
                 return False
-            await session.execute(update(Resume).where(Resume.is_master == True).values(is_master=False))
-            await session.execute(update(Resume).where(Resume.resume_id == resume_id).values(is_master=True))
+            await session.execute(
+                update(Resume).where(Resume.is_master == True, Resume.user_id == user_id).values(is_master=False)
+            )
+            await session.execute(
+                update(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id).values(is_master=True)
+            )
             await session.commit()
             return True
 
     # -- Job operations ------------------------------------------------------
 
-    async def create_job(self, content: str, resume_id: str | None = None) -> dict[str, Any]:
-        job = Job(job_id=str(uuid4()), content=content, resume_id=resume_id)
+    async def create_job(self, content: str, user_id: str, resume_id: str | None = None) -> dict[str, Any]:
+        job = Job(job_id=str(uuid4()), content=content, user_id=user_id, resume_id=resume_id)
         async with self._session() as session:
             session.add(job)
             await session.commit()
             await session.refresh(job)
             return self._job_to_dict(job)
 
-    async def get_job(self, job_id: str) -> dict[str, Any] | None:
+    async def get_job(self, job_id: str, user_id: str) -> dict[str, Any] | None:
         async with self._session() as session:
-            result = await session.execute(select(Job).where(Job.job_id == job_id))
+            result = await session.execute(
+                select(Job).where(Job.job_id == job_id, Job.user_id == user_id)
+            )
             row = result.scalar_one_or_none()
             return self._job_to_dict(row) if row else None
 
-    async def update_job(self, job_id: str, updates: dict[str, Any]) -> dict[str, Any] | None:
+    async def update_job(self, job_id: str, user_id: str, updates: dict[str, Any]) -> dict[str, Any] | None:
         async with self._session() as session:
-            result = await session.execute(update(Job).where(Job.job_id == job_id).values(**updates))
+            result = await session.execute(
+                update(Job).where(Job.job_id == job_id, Job.user_id == user_id).values(**updates)
+            )
             if result.rowcount == 0:
                 return None
             await session.commit()
-        return await self.get_job(job_id)
+        return await self.get_job(job_id, user_id)
 
     # -- Improvement operations ----------------------------------------------
 
     async def create_improvement(
         self, original_resume_id: str, tailored_resume_id: str,
-        job_id: str, improvements: list[dict[str, Any]],
+        job_id: str, improvements: list[dict[str, Any]], user_id: str,
     ) -> dict[str, Any]:
         imp = Improvement(
             request_id=str(uuid4()), original_resume_id=original_resume_id,
             tailored_resume_id=tailored_resume_id, job_id=job_id, improvements=improvements,
+            user_id=user_id,
         )
         async with self._session() as session:
             session.add(imp)
@@ -281,10 +301,13 @@ class Database:
             await session.refresh(imp)
             return self._improvement_to_dict(imp)
 
-    async def get_improvement_by_tailored_resume(self, tailored_resume_id: str) -> dict[str, Any] | None:
+    async def get_improvement_by_tailored_resume(self, tailored_resume_id: str, user_id: str) -> dict[str, Any] | None:
         async with self._session() as session:
             result = await session.execute(
-                select(Improvement).where(Improvement.tailored_resume_id == tailored_resume_id)
+                select(Improvement).where(
+                    Improvement.tailored_resume_id == tailored_resume_id,
+                    Improvement.user_id == user_id,
+                )
             )
             row = result.scalar_one_or_none()
             return self._improvement_to_dict(row) if row else None
@@ -471,12 +494,20 @@ class Database:
 
     # -- Stats & admin -------------------------------------------------------
 
-    async def get_stats(self) -> dict[str, Any]:
+    async def get_stats(self, user_id: str) -> dict[str, Any]:
         async with self._session() as session:
-            resume_count = (await session.execute(select(func.count()).select_from(Resume))).scalar() or 0
-            job_count = (await session.execute(select(func.count()).select_from(Job))).scalar() or 0
-            improvement_count = (await session.execute(select(func.count()).select_from(Improvement))).scalar() or 0
-            master = await session.execute(select(Resume).where(Resume.is_master == True))
+            resume_count = (await session.execute(
+                select(func.count()).select_from(Resume).where(Resume.user_id == user_id)
+            )).scalar() or 0
+            job_count = (await session.execute(
+                select(func.count()).select_from(Job).where(Job.user_id == user_id)
+            )).scalar() or 0
+            improvement_count = (await session.execute(
+                select(func.count()).select_from(Improvement).where(Improvement.user_id == user_id)
+            )).scalar() or 0
+            master = await session.execute(
+                select(Resume).where(Resume.is_master == True, Resume.user_id == user_id)
+            )
             return {
                 "total_resumes": resume_count,
                 "total_jobs": job_count,

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -90,9 +90,9 @@ async def root() -> dict:
 
 
 @app.get("/.well-known/oauth-authorization-server")
-async def oauth_server_metadata(request: Request) -> dict:
+async def oauth_server_metadata() -> dict:
     """RFC 8414 OAuth 2.1 Authorization Server Metadata."""
-    base = str(request.base_url).rstrip("/")
+    base = settings.frontend_base_url.rstrip("/")
     api_base = f"{base}/api/v1"
     return {
         "issuer": base,
@@ -116,9 +116,9 @@ async def jwks_endpoint() -> dict:
 
 
 @app.get("/.well-known/oauth-protected-resource")
-async def protected_resource_metadata(request: Request) -> dict:
+async def protected_resource_metadata() -> dict:
     """RFC 9728 OAuth 2.0 Protected Resource Metadata."""
-    base = str(request.base_url).rstrip("/")
+    base = settings.frontend_base_url.rstrip("/")
     return {
         "resource": base,
         "authorization_servers": [base],

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
-from app.auth.keys import load_rsa_keys
+from app.auth.keys import get_jwks, load_rsa_keys
 from app.config import settings
 from app.database import db
 from app.pdf import close_pdf_renderer, init_pdf_renderer
@@ -98,12 +98,31 @@ async def oauth_server_metadata(request: Request) -> dict:
         "authorization_endpoint": f"{api_base}/oauth/authorize",
         "token_endpoint": f"{api_base}/oauth/token",
         "revocation_endpoint": f"{api_base}/oauth/revoke",
-        "registration_endpoint": None,
+        "registration_endpoint": f"{api_base}/oauth/register",
+        "jwks_uri": f"{base}/.well-known/jwks.json",
         "response_types_supported": ["code"],
         "grant_types_supported": ["authorization_code", "refresh_token"],
         "code_challenge_methods_supported": ["S256"],
         "token_endpoint_auth_methods_supported": ["none"],
         "scopes_supported": ["openid", "profile", "email"],
+    }
+
+
+@app.get("/.well-known/jwks.json")
+async def jwks_endpoint() -> dict:
+    """RFC 7517 JSON Web Key Set — public key for token verification."""
+    return get_jwks()
+
+
+@app.get("/.well-known/oauth-protected-resource")
+async def protected_resource_metadata(request: Request) -> dict:
+    """RFC 9728 OAuth 2.0 Protected Resource Metadata."""
+    base = str(request.base_url).rstrip("/")
+    return {
+        "resource": base,
+        "authorization_servers": [base],
+        "bearer_methods_supported": ["header"],
+        "resource_name": "Resume Matcher",
     }
 
 

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -133,32 +133,35 @@ async def protected_resource_metadata(request: Request) -> dict:
 
 from fastapi.responses import RedirectResponse as _RedirectResponse
 
+from app.schemas.auth import (
+    ClientRegistrationRequest,
+    ClientRegistrationResponse,
+    TokenRequest,
+    TokenResponse,
+)
+
 
 @app.get("/authorize")
 async def root_authorize(request: Request) -> _RedirectResponse:
-    """Redirect GET /authorize to /api/v1/oauth/authorize with query params."""
+    """Redirect browser authorize to frontend login with OAuth params."""
     qs = str(request.query_params)
-    target = "/api/v1/oauth/authorize"
+    target = f"{settings.frontend_origin}/login"
     if qs:
         target = f"{target}?{qs}"
-    return _RedirectResponse(url=target, status_code=307)
+    return _RedirectResponse(url=target, status_code=302)
 
 
-@app.post("/register", status_code=201)
-async def root_register(request: Request):
+@app.post("/register", status_code=201, response_model=ClientRegistrationResponse)
+async def root_register(body: ClientRegistrationRequest) -> ClientRegistrationResponse:
     """Proxy POST /register to the DCR endpoint."""
-    from app.schemas.auth import ClientRegistrationRequest
     from app.routers.oauth import register_client
-    body = ClientRegistrationRequest(**(await request.json()))
     return await register_client(body)
 
 
-@app.post("/token")
-async def root_token(request: Request, response: Response):
+@app.post("/token", response_model=TokenResponse)
+async def root_token(body: TokenRequest, request: Request, response: Response) -> TokenResponse:
     """Proxy POST /token to the token endpoint."""
-    from app.schemas.auth import TokenRequest
     from app.routers.oauth import token as token_handler
-    body = TokenRequest(**(await request.json()))
     return await token_handler(body, request, response)
 
 

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 
 # Fix for Windows: Use ProactorEventLoop for subprocess support (Playwright)
 if sys.platform == "win32":
@@ -19,7 +19,7 @@ from app.auth.keys import get_jwks, load_rsa_keys
 from app.config import settings
 from app.database import db
 from app.pdf import close_pdf_renderer, init_pdf_renderer
-from app.routers import auth_router, config_router, enrichment_router, google_oauth_router, health_router, jobs_router, oauth_router, resumes_router
+from app.routers import auth_router, config_router, enrichment_router, google_oauth_router, health_router, jobs_router, mcp_router, oauth_router, resumes_router
 
 
 def _configure_application_logging() -> None:
@@ -76,6 +76,7 @@ app.include_router(config_router, prefix="/api/v1")
 app.include_router(resumes_router, prefix="/api/v1")
 app.include_router(jobs_router, prefix="/api/v1")
 app.include_router(enrichment_router, prefix="/api/v1")
+app.include_router(mcp_router)  # No prefix — mounted at /mcp directly
 
 
 @app.get("/")
@@ -124,6 +125,41 @@ async def protected_resource_metadata(request: Request) -> dict:
         "bearer_methods_supported": ["header"],
         "resource_name": "Resume Matcher",
     }
+
+
+# -- claude.ai compatibility proxies ------------------------------------------
+# claude.ai web appends /authorize, /token, /register to the server root,
+# ignoring the URLs in AS metadata. These thin proxies handle that quirk.
+
+from fastapi.responses import RedirectResponse as _RedirectResponse
+
+
+@app.get("/authorize")
+async def root_authorize(request: Request) -> _RedirectResponse:
+    """Redirect GET /authorize to /api/v1/oauth/authorize with query params."""
+    qs = str(request.query_params)
+    target = "/api/v1/oauth/authorize"
+    if qs:
+        target = f"{target}?{qs}"
+    return _RedirectResponse(url=target, status_code=307)
+
+
+@app.post("/register", status_code=201)
+async def root_register(request: Request):
+    """Proxy POST /register to the DCR endpoint."""
+    from app.schemas.auth import ClientRegistrationRequest
+    from app.routers.oauth import register_client
+    body = ClientRegistrationRequest(**(await request.json()))
+    return await register_client(body)
+
+
+@app.post("/token")
+async def root_token(request: Request, response: Response):
+    """Proxy POST /token to the token endpoint."""
+    from app.schemas.auth import TokenRequest
+    from app.routers.oauth import token as token_handler
+    body = TokenRequest(**(await request.json()))
+    return await token_handler(body, request, response)
 
 
 if __name__ == "__main__":

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 from fastapi.middleware.cors import CORSMiddleware
 
 from app import __version__
+from app.auth.keys import load_rsa_keys
 from app.config import settings
 from app.database import db
 from app.pdf import close_pdf_renderer, init_pdf_renderer
@@ -35,6 +36,10 @@ async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     settings.data_dir.mkdir(parents=True, exist_ok=True)
     await db.init()
+    load_rsa_keys(
+        pem_data=settings.rsa_private_key_pem or None,
+        key_file=str(settings.effective_rsa_key_file),
+    )
     yield
     try:
         await close_pdf_renderer()

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -110,3 +110,16 @@ class OAuthAccount(Base):
     __table_args__ = (
         UniqueConstraint("provider", "provider_user_id", name="uq_oauth_provider_user"),
     )
+
+
+class OAuthClient(Base):
+    """Dynamically registered OAuth clients (RFC 7591)."""
+    __tablename__ = "oauth_clients"
+    client_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    client_name: Mapped[str | None] = mapped_column(String(255))
+    redirect_uris: Mapped[list] = mapped_column(JSON, default=list)
+    grant_types: Mapped[list] = mapped_column(JSON, default=lambda: ["authorization_code"])
+    response_types: Mapped[list] = mapped_column(JSON, default=lambda: ["code"])
+    token_endpoint_auth_method: Mapped[str] = mapped_column(String(50), default="none")
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -30,7 +30,7 @@ class User(Base):
 class Resume(Base):
     __tablename__ = "resumes"
     resume_id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    user_id: Mapped[str | None] = mapped_column(ForeignKey("users.id"), index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
     content: Mapped[str] = mapped_column(Text)
     content_type: Mapped[str] = mapped_column(String(10), default="md")
     filename: Mapped[str | None] = mapped_column(String(255))
@@ -44,13 +44,13 @@ class Resume(Base):
     original_markdown: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
-    user: Mapped["User | None"] = relationship(back_populates="resumes")
+    user: Mapped["User"] = relationship(back_populates="resumes")
 
 
 class Job(Base):
     __tablename__ = "jobs"
     job_id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    user_id: Mapped[str | None] = mapped_column(ForeignKey("users.id"), index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
     content: Mapped[str] = mapped_column(Text)
     resume_id: Mapped[str | None] = mapped_column(ForeignKey("resumes.resume_id"), index=True)
     job_keywords: Mapped[dict | None] = mapped_column(nullable=True)
@@ -65,7 +65,7 @@ class Job(Base):
 class Improvement(Base):
     __tablename__ = "improvements"
     request_id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
-    user_id: Mapped[str | None] = mapped_column(ForeignKey("users.id"), index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
     original_resume_id: Mapped[str] = mapped_column(ForeignKey("resumes.resume_id"), index=True)
     tailored_resume_id: Mapped[str] = mapped_column(ForeignKey("resumes.resume_id"), index=True)
     job_id: Mapped[str] = mapped_column(ForeignKey("jobs.job_id"), index=True)

--- a/apps/backend/app/routers/__init__.py
+++ b/apps/backend/app/routers/__init__.py
@@ -6,12 +6,14 @@ from app.routers.enrichment import router as enrichment_router
 from app.routers.google_oauth import router as google_oauth_router
 from app.routers.health import router as health_router
 from app.routers.jobs import router as jobs_router
+from app.routers.mcp import router as mcp_router
 from app.routers.oauth import router as oauth_router
 from app.routers.resumes import router as resumes_router
 
 __all__ = [
     "auth_router",
     "google_oauth_router",
+    "mcp_router",
     "oauth_router",
     "resumes_router",
     "jobs_router",

--- a/apps/backend/app/routers/enrichment.py
+++ b/apps/backend/app/routers/enrichment.py
@@ -7,7 +7,9 @@ import logging
 import re
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.auth.dependencies import get_current_user
 
 from app.config_cache import get_content_language
 from app.database import db
@@ -85,14 +87,14 @@ def _extract_item_from_resume(processed_data: dict, item_id: str) -> dict:
 
 
 @router.post("/analyze/{resume_id}", response_model=AnalysisResponse)
-async def analyze_resume(resume_id: str) -> AnalysisResponse:
+async def analyze_resume(resume_id: str, user: dict = Depends(get_current_user)) -> AnalysisResponse:
     """Analyze a resume to identify items that need enrichment.
 
     Uses AI to examine Experience and Projects sections for weak,
     vague, or incomplete descriptions and generates clarifying questions.
     """
     # Fetch resume
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -155,14 +157,14 @@ async def analyze_resume(resume_id: str) -> AnalysisResponse:
 
 
 @router.post("/enhance", response_model=EnhancementPreview)
-async def generate_enhancements(request: EnhanceRequest) -> EnhancementPreview:
+async def generate_enhancements(request: EnhanceRequest, user: dict = Depends(get_current_user)) -> EnhancementPreview:
     """Generate enhanced descriptions from user answers.
 
     Takes the answers to clarifying questions and uses AI to generate
     improved description bullets for each item.
     """
     # Fetch resume
-    resume = await db.get_resume(request.resume_id)
+    resume = await db.get_resume(request.resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -297,7 +299,7 @@ async def generate_enhancements(request: EnhanceRequest) -> EnhancementPreview:
 
 @router.post("/apply/{resume_id}")
 async def apply_enhancements(
-    resume_id: str, request: ApplyEnhancementsRequest
+    resume_id: str, request: ApplyEnhancementsRequest, user: dict = Depends(get_current_user)
 ) -> dict:
     """Apply enhancements to the master resume.
 
@@ -305,7 +307,7 @@ async def apply_enhancements(
     the enhanced descriptions.
     """
     # Fetch resume
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -360,6 +362,7 @@ async def apply_enhancements(
     try:
         await db.update_resume(
             resume_id,
+            user["id"],
             {
                 "content": updated_content,
                 "processed_data": updated_data,
@@ -455,14 +458,14 @@ async def _regenerate_skills(
 
 
 @router.post("/regenerate", response_model=RegenerateResponse)
-async def regenerate_items(request: RegenerateRequest) -> RegenerateResponse:
+async def regenerate_items(request: RegenerateRequest, user: dict = Depends(get_current_user)) -> RegenerateResponse:
     """Regenerate selected resume items based on user feedback.
 
     Takes selected items (experience, projects, skills) and a user instruction,
     then uses AI to rewrite the content addressing the user's concerns.
     """
     # Validate resume exists
-    resume = await db.get_resume(request.resume_id)
+    resume = await db.get_resume(request.resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -516,7 +519,7 @@ async def regenerate_items(request: RegenerateRequest) -> RegenerateResponse:
 
 @router.post("/apply-regenerated/{resume_id}")
 async def apply_regenerated_items(
-    resume_id: str, regenerated_items: list[RegeneratedItem]
+    resume_id: str, regenerated_items: list[RegeneratedItem], user: dict = Depends(get_current_user)
 ) -> dict:
     """Apply regenerated items to the master resume.
 
@@ -524,7 +527,7 @@ async def apply_regenerated_items(
     the regenerated descriptions.
     """
     # Fetch resume
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -761,6 +764,7 @@ async def apply_regenerated_items(
     try:
         await db.update_resume(
             resume_id,
+            user["id"],
             {
                 "content": updated_content,
                 "processed_data": updated_data,

--- a/apps/backend/app/routers/google_oauth.py
+++ b/apps/backend/app/routers/google_oauth.py
@@ -70,6 +70,7 @@ async def google_start(
             status_code=302,
         )
 
+
     nonce = secrets.token_urlsafe(32)
     packed = pack_state(
         {

--- a/apps/backend/app/routers/google_oauth.py
+++ b/apps/backend/app/routers/google_oauth.py
@@ -70,7 +70,6 @@ async def google_start(
             status_code=302,
         )
 
-
     nonce = secrets.token_urlsafe(32)
     packed = pack_state(
         {

--- a/apps/backend/app/routers/health.py
+++ b/apps/backend/app/routers/health.py
@@ -1,6 +1,8 @@
 """Health check and status endpoints."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+
+from app.auth.dependencies import get_current_user
 
 from app.database import db
 from app.llm import check_llm_health, get_llm_config
@@ -21,7 +23,7 @@ async def health_check() -> HealthResponse:
 
 
 @router.get("/status", response_model=StatusResponse)
-async def get_status() -> StatusResponse:
+async def get_status(user: dict = Depends(get_current_user)) -> StatusResponse:
     """Get comprehensive application status.
 
     Returns:
@@ -31,7 +33,7 @@ async def get_status() -> StatusResponse:
     """
     config = get_llm_config()
     llm_status = await check_llm_health(config)
-    db_stats = await db.get_stats()
+    db_stats = await db.get_stats(user["id"])
 
     return StatusResponse(
         status="ready" if llm_status["healthy"] and db_stats["has_master_resume"] else "setup_required",

--- a/apps/backend/app/routers/jobs.py
+++ b/apps/backend/app/routers/jobs.py
@@ -1,6 +1,8 @@
 """Job description management endpoints."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.auth.dependencies import get_current_user
 
 from app.database import db
 from app.schemas import JobUploadRequest, JobUploadResponse
@@ -9,7 +11,7 @@ router = APIRouter(prefix="/jobs", tags=["Jobs"])
 
 
 @router.post("/upload", response_model=JobUploadResponse)
-async def upload_job_descriptions(request: JobUploadRequest) -> JobUploadResponse:
+async def upload_job_descriptions(request: JobUploadRequest, user: dict = Depends(get_current_user)) -> JobUploadResponse:
     """Upload one or more job descriptions.
 
     Stores the raw text for later use in resume tailoring.
@@ -25,6 +27,7 @@ async def upload_job_descriptions(request: JobUploadRequest) -> JobUploadRespons
 
         job = await db.create_job(
             content=jd.strip(),
+            user_id=user["id"],
             resume_id=request.resume_id,
         )
         job_ids.append(job["job_id"])
@@ -40,9 +43,9 @@ async def upload_job_descriptions(request: JobUploadRequest) -> JobUploadRespons
 
 
 @router.get("/{job_id}")
-async def get_job(job_id: str) -> dict:
+async def get_job(job_id: str, user: dict = Depends(get_current_user)) -> dict:
     """Get job description by ID."""
-    job = await db.get_job(job_id)
+    job = await db.get_job(job_id, user["id"])
 
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/apps/backend/app/routers/jobs.py
+++ b/apps/backend/app/routers/jobs.py
@@ -20,6 +20,11 @@ async def upload_job_descriptions(request: JobUploadRequest, user: dict = Depend
     if not request.job_descriptions:
         raise HTTPException(status_code=400, detail="No job descriptions provided")
 
+    if request.resume_id:
+        resume = await db.get_resume(request.resume_id, user["id"])
+        if not resume:
+            raise HTTPException(status_code=404, detail="Resume not found")
+
     job_ids = []
     for jd in request.job_descriptions:
         if not jd.strip():

--- a/apps/backend/app/routers/mcp.py
+++ b/apps/backend/app/routers/mcp.py
@@ -1,0 +1,234 @@
+"""MCP (Model Context Protocol) endpoint — JSON-RPC 2.0 over Streamable HTTP."""
+
+import json
+import logging
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from app.auth.jwt import verify_access_token
+from app.database import db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["mcp"])
+
+_PROTOCOL_VERSION = "2025-06-18"
+_SERVER_NAME = "resume-matcher"
+_SERVER_VERSION = "1.0.0"
+
+# -- Tool definitions ---------------------------------------------------------
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "list_resumes",
+        "description": "List all resumes belonging to the authenticated user.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "get_resume",
+        "description": "Get a specific resume by ID, including its processed content.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "resume_id": {"type": "string", "description": "The resume UUID"},
+            },
+            "required": ["resume_id"],
+        },
+    },
+    {
+        "name": "get_status",
+        "description": "Get dashboard stats: resume count, job count, improvements count.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "upload_job_description",
+        "description": "Upload a job description text. Optionally link to a resume.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "The job description text"},
+                "resume_id": {"type": "string", "description": "Optional resume ID to link"},
+            },
+            "required": ["content"],
+        },
+    },
+    {
+        "name": "set_master_resume",
+        "description": "Set a resume as the master (source of truth) resume.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "resume_id": {"type": "string", "description": "The resume UUID to set as master"},
+            },
+            "required": ["resume_id"],
+        },
+    },
+]
+
+
+# -- Tool handlers ------------------------------------------------------------
+
+async def _tool_list_resumes(user: dict, _args: dict) -> str:
+    resumes = await db.list_resumes(user["id"])
+    if not resumes:
+        return "No resumes found."
+    lines = []
+    for r in resumes:
+        master = " [MASTER]" if r.get("is_master") else ""
+        title = r.get("title") or r.get("filename") or "Untitled"
+        lines.append(f"- {title} (id: {r['resume_id']}){master}")
+    return "\n".join(lines)
+
+
+async def _tool_get_resume(user: dict, args: dict) -> str:
+    resume_id = args.get("resume_id")
+    if not resume_id:
+        return "Error: resume_id is required"
+    resume = await db.get_resume(resume_id, user["id"])
+    if not resume:
+        return "Resume not found."
+    return json.dumps(resume, indent=2, default=str)
+
+
+async def _tool_get_status(user: dict, _args: dict) -> str:
+    stats = await db.get_stats(user["id"])
+    return json.dumps(stats, indent=2)
+
+
+async def _tool_upload_job(user: dict, args: dict) -> str:
+    content = args.get("content")
+    if not content:
+        return "Error: content is required"
+    resume_id = args.get("resume_id")
+    if resume_id:
+        resume = await db.get_resume(resume_id, user["id"])
+        if not resume:
+            return "Error: resume not found"
+    job = await db.create_job(content=content, user_id=user["id"], resume_id=resume_id)
+    return f"Job created: {job['job_id']}"
+
+
+async def _tool_set_master(user: dict, args: dict) -> str:
+    resume_id = args.get("resume_id")
+    if not resume_id:
+        return "Error: resume_id is required"
+    ok = await db.set_master_resume(resume_id, user["id"])
+    if ok:
+        return f"Resume {resume_id} set as master."
+    return "Error: resume not found."
+
+
+_TOOL_HANDLERS: dict[str, Any] = {
+    "list_resumes": _tool_list_resumes,
+    "get_resume": _tool_get_resume,
+    "get_status": _tool_get_status,
+    "upload_job_description": _tool_upload_job,
+    "set_master_resume": _tool_set_master,
+}
+
+
+# -- JSON-RPC helpers ---------------------------------------------------------
+
+def _jsonrpc_result(msg_id: int | str | None, result: Any) -> dict:
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def _jsonrpc_error(msg_id: int | str | None, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+
+# -- Auth helper --------------------------------------------------------------
+
+async def _resolve_user(request: Request) -> dict | None:
+    """Extract Bearer token and resolve user. Returns None if not authenticated."""
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+    token = auth_header[7:]
+    try:
+        claims = verify_access_token(token)
+    except ValueError:
+        return None
+    return await db.get_user_by_id(claims["sub"])
+
+
+# -- Main handler -------------------------------------------------------------
+
+@router.post("/mcp")
+async def mcp_handler(request: Request) -> JSONResponse:
+    """MCP Streamable HTTP endpoint (JSON-RPC 2.0)."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            content=_jsonrpc_error(None, -32700, "Parse error"),
+            status_code=200,
+        )
+
+    if isinstance(body, list):
+        return JSONResponse(
+            content=_jsonrpc_error(None, -32600, "Batch requests not supported"),
+            status_code=200,
+        )
+
+    method = body.get("method")
+    msg_id = body.get("id")
+    params = body.get("params", {})
+
+    # -- initialize (no auth required) --
+    if method == "initialize":
+        result = {
+            "protocolVersion": _PROTOCOL_VERSION,
+            "serverInfo": {"name": _SERVER_NAME, "version": _SERVER_VERSION},
+            "capabilities": {"tools": {"listChanged": False}},
+        }
+        session_id = str(uuid4())
+        return JSONResponse(
+            content=_jsonrpc_result(msg_id, result),
+            headers={"mcp-session-id": session_id},
+        )
+
+    # -- notifications (no response) --
+    if method == "notifications/initialized":
+        return JSONResponse(content=None, status_code=204)
+
+    # -- Auth required for all other methods --
+    user = await _resolve_user(request)
+    if not user:
+        return JSONResponse(
+            content=_jsonrpc_error(msg_id, -32600, "Unauthorized — Bearer token required"),
+            status_code=200,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # -- tools/list --
+    if method == "tools/list":
+        return JSONResponse(content=_jsonrpc_result(msg_id, {"tools": TOOLS}))
+
+    # -- tools/call --
+    if method == "tools/call":
+        tool_name = params.get("name")
+        tool_args = params.get("arguments", {})
+
+        handler = _TOOL_HANDLERS.get(tool_name)
+        if not handler:
+            return JSONResponse(
+                content=_jsonrpc_error(msg_id, -32602, f"Unknown tool: {tool_name}"),
+            )
+
+        try:
+            text_result = await handler(user, tool_args)
+        except Exception as e:
+            logger.error("MCP tool %s failed: %s", tool_name, e, exc_info=True)
+            return JSONResponse(
+                content=_jsonrpc_error(msg_id, -32603, f"Tool execution failed: {e}"),
+            )
+
+        return JSONResponse(content=_jsonrpc_result(msg_id, {
+            "content": [{"type": "text", "text": text_result}],
+        }))
+
+    return JSONResponse(content=_jsonrpc_error(msg_id, -32601, f"Method not found: {method}"))

--- a/apps/backend/app/routers/mcp.py
+++ b/apps/backend/app/routers/mcp.py
@@ -162,7 +162,7 @@ async def mcp_handler(request: Request) -> JSONResponse:
     """MCP Streamable HTTP endpoint (JSON-RPC 2.0)."""
     try:
         body = await request.json()
-    except Exception:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return JSONResponse(
             content=_jsonrpc_error(None, -32700, "Parse error"),
             status_code=200,
@@ -173,10 +173,20 @@ async def mcp_handler(request: Request) -> JSONResponse:
             content=_jsonrpc_error(None, -32600, "Batch requests not supported"),
             status_code=200,
         )
+    if not isinstance(body, dict):
+        return JSONResponse(
+            content=_jsonrpc_error(None, -32600, "Invalid Request"),
+            status_code=200,
+        )
 
     method = body.get("method")
     msg_id = body.get("id")
-    params = body.get("params", {})
+    params = body.get("params") or {}
+    if not isinstance(params, dict):
+        return JSONResponse(
+            content=_jsonrpc_error(msg_id, -32600, "Invalid Request"),
+            status_code=200,
+        )
 
     # -- initialize (no auth required) --
     if method == "initialize":
@@ -211,7 +221,11 @@ async def mcp_handler(request: Request) -> JSONResponse:
     # -- tools/call --
     if method == "tools/call":
         tool_name = params.get("name")
-        tool_args = params.get("arguments", {})
+        tool_args = params.get("arguments") or {}
+        if not isinstance(tool_args, dict):
+            return JSONResponse(
+                content=_jsonrpc_error(msg_id, -32602, "Invalid params"),
+            )
 
         handler = _TOOL_HANDLERS.get(tool_name)
         if not handler:
@@ -221,10 +235,10 @@ async def mcp_handler(request: Request) -> JSONResponse:
 
         try:
             text_result = await handler(user, tool_args)
-        except Exception as e:
-            logger.error("MCP tool %s failed: %s", tool_name, e, exc_info=True)
+        except Exception:
+            logger.exception("MCP tool %s failed", tool_name)
             return JSONResponse(
-                content=_jsonrpc_error(msg_id, -32603, f"Tool execution failed: {e}"),
+                content=_jsonrpc_error(msg_id, -32603, "Tool execution failed"),
             )
 
         return JSONResponse(content=_jsonrpc_result(msg_id, {

--- a/apps/backend/app/routers/oauth.py
+++ b/apps/backend/app/routers/oauth.py
@@ -21,7 +21,7 @@ from app.auth.password import verify_password
 from app.auth.pkce import verify_code_challenge
 from app.config import settings
 from app.database import db
-from app.schemas.auth import AuthorizeRequest, TokenRequest, TokenResponse
+from app.schemas.auth import AuthorizeRequest, ClientRegistrationRequest, ClientRegistrationResponse, TokenRequest, TokenResponse
 
 logger = logging.getLogger(__name__)
 
@@ -37,18 +37,27 @@ def _allowed_redirect_uris() -> list[str]:
     return uris
 
 
-def _validate_client(client_id: str, redirect_uri: str) -> None:
-    """Validate client_id and redirect_uri against known clients."""
-    if client_id != FIRST_PARTY_CLIENT_ID:
+async def _validate_client(client_id: str, redirect_uri: str) -> None:
+    """Validate client_id and redirect_uri against registered clients."""
+    oauth_client = await db.get_oauth_client(client_id)
+    if not oauth_client or not oauth_client["is_active"]:
         raise HTTPException(status_code=400, detail="Unknown client_id")
-    if redirect_uri not in _allowed_redirect_uris():
+
+    allowed = list(oauth_client["redirect_uris"])
+    # First-party client also accepts dynamic frontend origin
+    if client_id == FIRST_PARTY_CLIENT_ID:
+        dynamic = f"{settings.frontend_origin.rstrip('/')}/callback"
+        if dynamic not in allowed:
+            allowed.append(dynamic)
+
+    if redirect_uri not in allowed:
         raise HTTPException(status_code=400, detail="Invalid redirect_uri")
 
 
 @router.post("/authorize")
 async def authorize(body: AuthorizeRequest) -> Response:
     """OAuth 2.1 authorization endpoint with embedded credentials."""
-    _validate_client(body.client_id, body.redirect_uri)
+    await _validate_client(body.client_id, body.redirect_uri)
 
     if body.code_challenge_method != "S256":
         raise HTTPException(status_code=400, detail="Only S256 is supported")
@@ -224,3 +233,25 @@ async def revoke(request: Request, response: Response) -> dict:
     response.delete_cookie("refresh_token", path="/api/v1/oauth/token")
     response.delete_cookie("has_session", path="/")
     return {"status": "ok"}
+
+
+@router.post("/register", status_code=201)
+async def register_client(body: ClientRegistrationRequest) -> ClientRegistrationResponse:
+    """RFC 7591 Dynamic Client Registration."""
+    import time
+    client = await db.create_oauth_client(
+        client_name=body.client_name,
+        redirect_uris=body.redirect_uris,
+        grant_types=body.grant_types,
+        response_types=body.response_types,
+        token_endpoint_auth_method=body.token_endpoint_auth_method,
+    )
+    return ClientRegistrationResponse(
+        client_id=client["client_id"],
+        client_name=client["client_name"],
+        redirect_uris=client["redirect_uris"],
+        grant_types=client["grant_types"],
+        response_types=client["response_types"],
+        token_endpoint_auth_method=client["token_endpoint_auth_method"],
+        client_id_issued_at=int(time.time()),
+    )

--- a/apps/backend/app/routers/oauth.py
+++ b/apps/backend/app/routers/oauth.py
@@ -54,6 +54,16 @@ async def _validate_client(client_id: str, redirect_uri: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid redirect_uri")
 
 
+@router.get("/authorize")
+async def authorize_get(request: Request) -> RedirectResponse:
+    """GET authorize → redirect browser to frontend login with OAuth params."""
+    qs = str(request.query_params)
+    target = f"{settings.frontend_origin.rstrip('/')}/login"
+    if qs:
+        target = f"{target}?{qs}"
+    return RedirectResponse(url=target, status_code=302)
+
+
 @router.post("/authorize")
 async def authorize(body: AuthorizeRequest) -> Response:
     """OAuth 2.1 authorization endpoint with embedded credentials."""

--- a/apps/backend/app/routers/oauth.py
+++ b/apps/backend/app/routers/oauth.py
@@ -170,7 +170,6 @@ async def _issue_tokens(
     access_token = create_access_token(
         user_id=user["id"],
         email=user["email"],
-        secret=settings.effective_jwt_secret,
     )
 
     raw_refresh = secrets.token_urlsafe(32)

--- a/apps/backend/app/routers/oauth.py
+++ b/apps/backend/app/routers/oauth.py
@@ -1,6 +1,7 @@
 """OAuth 2.1 endpoints: authorize, token, revoke, discovery."""
 
 import hashlib
+import json
 import logging
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -98,12 +99,17 @@ async def authorize(body: AuthorizeRequest) -> Response:
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=AUTHORIZATION_CODE_EXPIRE_MINUTES),
     )
 
-    # Redirect with code
+    # Return redirect URL as JSON so the frontend SPA can navigate.
+    # (fetch with redirect:'manual' can't read Location headers from opaque redirects)
     params: dict[str, str] = {"code": code}
     if body.state:
         params["state"] = body.state
     redirect_url = f"{body.redirect_uri}?{urlencode(params)}"
-    return RedirectResponse(url=redirect_url, status_code=303)
+    return Response(
+        content=json.dumps({"redirect_url": redirect_url}),
+        status_code=200,
+        media_type="application/json",
+    )
 
 
 @router.post("/token", response_model=TokenResponse)

--- a/apps/backend/app/routers/resumes.py
+++ b/apps/backend/app/routers/resumes.py
@@ -11,8 +11,10 @@ from pathlib import Path
 from typing import Any, NoReturn
 from uuid import uuid4
 
-from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import Response
+
+from app.auth.dependencies import get_current_user
 
 from app.config_cache import get_content_language, load_config as _load_config
 from app.database import db
@@ -507,7 +509,7 @@ MAX_FILE_SIZE = 4 * 1024 * 1024  # 4MB
 
 
 @router.post("/upload", response_model=ResumeUploadResponse)
-async def upload_resume(file: UploadFile = File(...)) -> ResumeUploadResponse:
+async def upload_resume(file: UploadFile = File(...), user: dict = Depends(get_current_user)) -> ResumeUploadResponse:
     """Upload and process a resume file (PDF/DOCX).
 
     Converts the file to Markdown and stores it in the database.
@@ -546,6 +548,7 @@ async def upload_resume(file: UploadFile = File(...)) -> ResumeUploadResponse:
     # builder saves overwrite `content` with JSON.
     resume = await db.create_resume_atomic_master(
         content=markdown_content,
+        user_id=user["id"],
         content_type="md",
         filename=file.filename,
         processed_data=None,
@@ -558,6 +561,7 @@ async def upload_resume(file: UploadFile = File(...)) -> ResumeUploadResponse:
         processed_data = await parse_resume_to_json(markdown_content)
         await db.update_resume(
             resume["resume_id"],
+            user["id"],
             {
                 "processed_data": processed_data,
                 "processing_status": "ready",
@@ -568,7 +572,7 @@ async def upload_resume(file: UploadFile = File(...)) -> ResumeUploadResponse:
     except Exception as e:
         # LLM parsing failed, update status to failed
         logger.warning(f"Resume parsing to JSON failed for {file.filename}: {e}")
-        await db.update_resume(resume["resume_id"], {"processing_status": "failed"})
+        await db.update_resume(resume["resume_id"], user["id"], {"processing_status": "failed"})
         resume["processing_status"] = "failed"
 
     # Return accurate status to client (API-001 fix)
@@ -586,14 +590,14 @@ async def upload_resume(file: UploadFile = File(...)) -> ResumeUploadResponse:
 
 
 @router.get("", response_model=ResumeFetchResponse)
-async def get_resume(resume_id: str = Query(...)) -> ResumeFetchResponse:
+async def get_resume(resume_id: str = Query(...), user: dict = Depends(get_current_user)) -> ResumeFetchResponse:
     """Fetch resume details by ID.
 
     Returns both raw markdown and structured data (if available),
     plus cover letter and outreach message if they exist.
     Applies lazy migration for section metadata if needed.
     """
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
 
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
@@ -636,9 +640,9 @@ async def get_resume(resume_id: str = Query(...)) -> ResumeFetchResponse:
 
 
 @router.get("/list", response_model=ResumeListResponse)
-async def list_resumes(include_master: bool = Query(False)) -> ResumeListResponse:
+async def list_resumes(include_master: bool = Query(False), user: dict = Depends(get_current_user)) -> ResumeListResponse:
     """List resumes, optionally including the master resume."""
-    resumes = await db.list_resumes()
+    resumes = await db.list_resumes(user["id"])
     if not include_master:
         resumes = [resume for resume in resumes if not resume.get("is_master", False)]
 
@@ -664,16 +668,17 @@ async def list_resumes(include_master: bool = Query(False)) -> ResumeListRespons
 @router.post("/improve/preview", response_model=ImproveResumeResponse)
 async def improve_resume_preview_endpoint(
     request: ImproveResumeRequest,
+    user: dict = Depends(get_current_user),
 ) -> ImproveResumeResponse:
     """Preview a tailored resume without persisting it.
 
     The response includes resume_preview data but leaves resume_id null.
     """
-    resume = await db.get_resume(request.resume_id)
+    resume = await db.get_resume(request.resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
-    job = await db.get_job(request.job_id)
+    job = await db.get_job(request.job_id, user["id"])
     if not job:
         raise HTTPException(status_code=404, detail="Job description not found")
 
@@ -690,6 +695,7 @@ async def improve_resume_preview_endpoint(
                 job=job,
                 language=language,
                 prompt_id=prompt_id,
+                user_id=user["id"],
             ),
             timeout=240.0,  # 4-minute hard limit
         )
@@ -714,6 +720,7 @@ async def _improve_preview_flow(
     job: dict[str, Any],
     language: str,
     prompt_id: str,
+    user_id: str,
 ) -> ImproveResumeResponse:
     """Inner flow for improve/preview, extracted so it can be wrapped in wait_for."""
     job_keywords = job.get("job_keywords")
@@ -725,6 +732,7 @@ async def _improve_preview_flow(
         try:
             updated_job = await db.update_job(
                 request.job_id,
+                user_id,
                 {"job_keywords": job_keywords, "job_keywords_hash": content_hash},
             )
             if not updated_job:
@@ -808,7 +816,7 @@ async def _improve_preview_flow(
     refinement_successful = False
     try:
         # Get master resume for alignment validation
-        master_resume = await db.get_master_resume()
+        master_resume = await db.get_master_resume(user_id)
         master_data = (
             _get_original_resume_data(master_resume)
             if master_resume
@@ -868,6 +876,7 @@ async def _improve_preview_flow(
     try:
         updated_job = await db.update_job(
             request.job_id,
+            user_id,
             {
                 "preview_hash": preview_hash,
                 "preview_prompt_id": prompt_id,
@@ -922,13 +931,14 @@ async def _improve_preview_flow(
 @router.post("/improve/confirm", response_model=ImproveResumeResponse)
 async def improve_resume_confirm_endpoint(
     request: ImproveResumeConfirmRequest,
+    user: dict = Depends(get_current_user),
 ) -> ImproveResumeResponse:
     """Confirm and persist a tailored resume."""
-    resume = await db.get_resume(request.resume_id)
+    resume = await db.get_resume(request.resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
-    job = await db.get_job(request.job_id)
+    job = await db.get_job(request.job_id, user["id"])
     if not job:
         raise HTTPException(status_code=404, detail="Job description not found")
 
@@ -1010,6 +1020,7 @@ async def improve_resume_confirm_endpoint(
         stage = "create_resume"
         tailored_resume = await db.create_resume(
             content=improved_text,
+            user_id=user["id"],
             content_type="json",
             filename=f"tailored_{resume.get('filename', 'resume')}",
             is_master=False,
@@ -1029,6 +1040,7 @@ async def improve_resume_confirm_endpoint(
             tailored_resume_id=tailored_resume["resume_id"],
             job_id=request.job_id,
             improvements=improvements_payload,
+            user_id=user["id"],
         )
 
         return ImproveResumeResponse(
@@ -1057,6 +1069,7 @@ async def improve_resume_confirm_endpoint(
 @router.post("/improve", response_model=ImproveResumeResponse)
 async def improve_resume_endpoint(
     request: ImproveResumeRequest,
+    user: dict = Depends(get_current_user),
 ) -> ImproveResumeResponse:
     """Improve/tailor a resume for a specific job description.
 
@@ -1066,12 +1079,12 @@ async def improve_resume_endpoint(
     Persists the tailored resume and returns a non-null resume_id.
     """
     # Fetch resume
-    resume = await db.get_resume(request.resume_id)
+    resume = await db.get_resume(request.resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
     # Fetch job description
-    job = await db.get_job(request.job_id)
+    job = await db.get_job(request.job_id, user["id"])
     if not job:
         raise HTTPException(status_code=404, detail="Job description not found")
 
@@ -1158,7 +1171,7 @@ async def improve_resume_endpoint(
         refinement_successful = False
         try:
             # Get master resume for alignment validation
-            master_resume = await db.get_master_resume()
+            master_resume = await db.get_master_resume(user["id"])
             master_data = (
                 _get_original_resume_data(master_resume)
                 if master_resume
@@ -1240,6 +1253,7 @@ async def improve_resume_endpoint(
         # Store the tailored resume with cover letter, outreach message, and title
         tailored_resume = await db.create_resume(
             content=improved_text,
+            user_id=user["id"],
             content_type="json",
             filename=f"tailored_{resume.get('filename', 'resume')}",
             is_master=False,
@@ -1258,6 +1272,7 @@ async def improve_resume_endpoint(
             tailored_resume_id=tailored_resume["resume_id"],
             job_id=request.job_id,
             improvements=improvements,
+            user_id=user["id"],
         )
 
         return ImproveResumeResponse(
@@ -1298,10 +1313,10 @@ async def improve_resume_endpoint(
 
 @router.patch("/{resume_id}", response_model=ResumeFetchResponse)
 async def update_resume_endpoint(
-    resume_id: str, resume_data: ResumeData
+    resume_id: str, resume_data: ResumeData, user: dict = Depends(get_current_user)
 ) -> ResumeFetchResponse:
     """Update a resume with new structured data."""
-    existing = await db.get_resume(resume_id)
+    existing = await db.get_resume(resume_id, user["id"])
     if not existing:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -1310,6 +1325,7 @@ async def update_resume_endpoint(
 
     updated = await db.update_resume(
         resume_id,
+        user["id"],
         {
             "content": updated_content,
             "content_type": "json",
@@ -1365,6 +1381,7 @@ async def download_resume_pdf(
     showContactIcons: bool = Query(False),
     accentColor: str = Query("blue", pattern="^(blue|green|orange|red)$"),
     lang: str | None = Query(None, pattern="^[a-z]{2}(-[A-Z]{2})?$"),
+    user: dict = Depends(get_current_user),
 ) -> Response:
     """Generate a PDF for a resume using headless Chromium.
 
@@ -1383,7 +1400,7 @@ async def download_resume_pdf(
     - showContactIcons: show icons in contact info
     - lang: locale used for print page translations
     """
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -1429,22 +1446,22 @@ async def download_resume_pdf(
 
 
 @router.delete("/{resume_id}")
-async def delete_resume(resume_id: str) -> dict:
+async def delete_resume(resume_id: str, user: dict = Depends(get_current_user)) -> dict:
     """Delete a resume by ID."""
-    if not await db.delete_resume(resume_id):
+    if not await db.delete_resume(resume_id, user["id"]):
         raise HTTPException(status_code=404, detail="Resume not found")
 
     return {"message": "Resume deleted successfully"}
 
 
 @router.post("/{resume_id}/retry-processing", response_model=ResumeUploadResponse)
-async def retry_processing(resume_id: str) -> ResumeUploadResponse:
+async def retry_processing(resume_id: str, user: dict = Depends(get_current_user)) -> ResumeUploadResponse:
     """Retry AI processing for a failed or stuck resume.
 
     Re-runs parse_resume_to_json() on the stored markdown content.
     Works for resumes with processing_status == "failed" or "processing".
     """
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -1465,6 +1482,7 @@ async def retry_processing(resume_id: str) -> ResumeUploadResponse:
         processed_data = await parse_resume_to_json(markdown_content)
         await db.update_resume(
             resume_id,
+            user["id"],
             {
                 "processed_data": processed_data,
                 "processing_status": "ready",
@@ -1479,7 +1497,7 @@ async def retry_processing(resume_id: str) -> ResumeUploadResponse:
         )
     except Exception as e:
         logger.warning(f"Retry processing failed for resume {resume_id}: {e}")
-        await db.update_resume(resume_id, {"processing_status": "failed"})
+        await db.update_resume(resume_id, user["id"], {"processing_status": "failed"})
         return ResumeUploadResponse(
             message="Retry processing failed",
             request_id=str(uuid4()),
@@ -1491,46 +1509,46 @@ async def retry_processing(resume_id: str) -> ResumeUploadResponse:
 
 @router.patch("/{resume_id}/cover-letter")
 async def update_cover_letter(
-    resume_id: str, request: UpdateCoverLetterRequest
+    resume_id: str, request: UpdateCoverLetterRequest, user: dict = Depends(get_current_user)
 ) -> dict:
     """Update the cover letter for a resume."""
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
-    await db.update_resume(resume_id, {"cover_letter": request.content})
+    await db.update_resume(resume_id, user["id"], {"cover_letter": request.content})
     return {"message": "Cover letter updated successfully"}
 
 
 @router.patch("/{resume_id}/outreach-message")
 async def update_outreach_message(
-    resume_id: str, request: UpdateOutreachMessageRequest
+    resume_id: str, request: UpdateOutreachMessageRequest, user: dict = Depends(get_current_user)
 ) -> dict:
     """Update the outreach message for a resume."""
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
-    await db.update_resume(resume_id, {"outreach_message": request.content})
+    await db.update_resume(resume_id, user["id"], {"outreach_message": request.content})
     return {"message": "Outreach message updated successfully"}
 
 
 @router.patch("/{resume_id}/title")
-async def update_title(resume_id: str, request: UpdateTitleRequest) -> dict:
+async def update_title(resume_id: str, request: UpdateTitleRequest, user: dict = Depends(get_current_user)) -> dict:
     """Update the title for a resume."""
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
     title = request.title.strip()[:80]
-    await db.update_resume(resume_id, {"title": title})
+    await db.update_resume(resume_id, user["id"], {"title": title})
     return {"message": "Title updated successfully"}
 
 
 @router.post(
     "/{resume_id}/generate-cover-letter", response_model=GenerateContentResponse
 )
-async def generate_cover_letter_endpoint(resume_id: str) -> GenerateContentResponse:
+async def generate_cover_letter_endpoint(resume_id: str, user: dict = Depends(get_current_user)) -> GenerateContentResponse:
     """Generate a cover letter on-demand for an existing tailored resume.
 
     This endpoint allows users to generate a cover letter after a resume has been
@@ -1539,7 +1557,7 @@ async def generate_cover_letter_endpoint(resume_id: str) -> GenerateContentRespo
     - The resume must have an associated job context in the improvements table
     """
     # Get the resume
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -1552,7 +1570,7 @@ async def generate_cover_letter_endpoint(resume_id: str) -> GenerateContentRespo
         )
 
     # Get improvement record to find the job_id
-    improvement = await db.get_improvement_by_tailored_resume(resume_id)
+    improvement = await db.get_improvement_by_tailored_resume(resume_id, user["id"])
     if not improvement:
         raise HTTPException(
             status_code=400,
@@ -1561,7 +1579,7 @@ async def generate_cover_letter_endpoint(resume_id: str) -> GenerateContentRespo
         )
 
     # Get the job description
-    job = await db.get_job(improvement["job_id"])
+    job = await db.get_job(improvement["job_id"], user["id"])
     if not job:
         raise HTTPException(
             status_code=404,
@@ -1592,7 +1610,7 @@ async def generate_cover_letter_endpoint(resume_id: str) -> GenerateContentRespo
         )
 
     # Save to resume record
-    await db.update_resume(resume_id, {"cover_letter": cover_letter_content})
+    await db.update_resume(resume_id, user["id"], {"cover_letter": cover_letter_content})
 
     return GenerateContentResponse(
         content=cover_letter_content,
@@ -1601,7 +1619,7 @@ async def generate_cover_letter_endpoint(resume_id: str) -> GenerateContentRespo
 
 
 @router.post("/{resume_id}/generate-outreach", response_model=GenerateContentResponse)
-async def generate_outreach_endpoint(resume_id: str) -> GenerateContentResponse:
+async def generate_outreach_endpoint(resume_id: str, user: dict = Depends(get_current_user)) -> GenerateContentResponse:
     """Generate an outreach message on-demand for an existing tailored resume.
 
     This endpoint allows users to generate a cold outreach message after a resume
@@ -1610,7 +1628,7 @@ async def generate_outreach_endpoint(resume_id: str) -> GenerateContentResponse:
     - The resume must have an associated job context in the improvements table
     """
     # Get the resume
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -1623,7 +1641,7 @@ async def generate_outreach_endpoint(resume_id: str) -> GenerateContentResponse:
         )
 
     # Get improvement record to find the job_id
-    improvement = await db.get_improvement_by_tailored_resume(resume_id)
+    improvement = await db.get_improvement_by_tailored_resume(resume_id, user["id"])
     if not improvement:
         raise HTTPException(
             status_code=400,
@@ -1632,7 +1650,7 @@ async def generate_outreach_endpoint(resume_id: str) -> GenerateContentResponse:
         )
 
     # Get the job description
-    job = await db.get_job(improvement["job_id"])
+    job = await db.get_job(improvement["job_id"], user["id"])
     if not job:
         raise HTTPException(
             status_code=404,
@@ -1663,7 +1681,7 @@ async def generate_outreach_endpoint(resume_id: str) -> GenerateContentResponse:
         )
 
     # Save to resume record
-    await db.update_resume(resume_id, {"outreach_message": outreach_content})
+    await db.update_resume(resume_id, user["id"], {"outreach_message": outreach_content})
 
     return GenerateContentResponse(
         content=outreach_content,
@@ -1672,14 +1690,14 @@ async def generate_outreach_endpoint(resume_id: str) -> GenerateContentResponse:
 
 
 @router.get("/{resume_id}/job-description")
-async def get_job_description_for_resume(resume_id: str) -> dict:
+async def get_job_description_for_resume(resume_id: str, user: dict = Depends(get_current_user)) -> dict:
     """Get the job description used to tailor this resume.
 
     This endpoint retrieves the original job description that was used
     to tailor a resume. Only works for tailored resumes (those with parent_id).
     """
     # Get the resume
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 
@@ -1691,7 +1709,7 @@ async def get_job_description_for_resume(resume_id: str) -> dict:
         )
 
     # Get improvement record to find the job_id
-    improvement = await db.get_improvement_by_tailored_resume(resume_id)
+    improvement = await db.get_improvement_by_tailored_resume(resume_id, user["id"])
     if not improvement:
         raise HTTPException(
             status_code=400,
@@ -1700,7 +1718,7 @@ async def get_job_description_for_resume(resume_id: str) -> dict:
         )
 
     # Get the job description
-    job = await db.get_job(improvement["job_id"])
+    job = await db.get_job(improvement["job_id"], user["id"])
     if not job:
         raise HTTPException(
             status_code=404,
@@ -1718,6 +1736,7 @@ async def download_cover_letter_pdf(
     resume_id: str,
     pageSize: str = Query("A4", pattern="^(A4|LETTER)$"),
     lang: str | None = Query(None, pattern="^[a-z]{2}(-[A-Z]{2})?$"),
+    user: dict = Depends(get_current_user),
 ) -> Response:
     """Generate a PDF for a cover letter using headless Chromium.
 
@@ -1726,7 +1745,7 @@ async def download_cover_letter_pdf(
         pageSize: A4 or LETTER
         lang: locale used for print page translations
     """
-    resume = await db.get_resume(resume_id)
+    resume = await db.get_resume(resume_id, user["id"])
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
 

--- a/apps/backend/app/schemas/auth.py
+++ b/apps/backend/app/schemas/auth.py
@@ -54,3 +54,23 @@ class ErrorResponse(BaseModel):
     """RFC 6750 error response."""
     error: str
     error_description: str | None = None
+
+
+class ClientRegistrationRequest(BaseModel):
+    """RFC 7591 Dynamic Client Registration request."""
+    redirect_uris: list[str] = Field(min_length=1)
+    client_name: str | None = None
+    token_endpoint_auth_method: str = "none"
+    grant_types: list[str] = Field(default=["authorization_code"])
+    response_types: list[str] = Field(default=["code"])
+
+
+class ClientRegistrationResponse(BaseModel):
+    """RFC 7591 Dynamic Client Registration response."""
+    client_id: str
+    client_name: str | None
+    redirect_uris: list[str]
+    grant_types: list[str]
+    response_types: list[str]
+    token_endpoint_auth_method: str
+    client_id_issued_at: int

--- a/apps/backend/app/schemas/auth.py
+++ b/apps/backend/app/schemas/auth.py
@@ -1,5 +1,7 @@
 """Pydantic schemas for authentication endpoints."""
 
+from typing import Literal
+
 from pydantic import BaseModel, EmailStr, Field
 
 
@@ -60,7 +62,7 @@ class ClientRegistrationRequest(BaseModel):
     """RFC 7591 Dynamic Client Registration request."""
     redirect_uris: list[str] = Field(min_length=1)
     client_name: str | None = None
-    token_endpoint_auth_method: str = "none"
+    token_endpoint_auth_method: Literal["none"] = "none"
     grant_types: list[str] = Field(default=["authorization_code"])
     response_types: list[str] = Field(default=["code"])
 

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -39,7 +39,9 @@ async def client(test_db, jwt_secret, monkeypatch):
     the routers, services **and** the lifespan all talk to the in-memory
     test database.
     """
-    # Load RSA keys for JWT signing (inline to avoid async fixture chain issues)
+    # Load RSA keys and seed OAuth client inline (duplicates rsa_keys and
+    # first_party_client fixtures) to avoid pytest-asyncio issues with
+    # complex async fixture dependency chains.
     from joserfc.jwk import RSAKey as _RSAKey
     reset_keys()
     _key = _RSAKey.generate_key(2048)

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.auth.jwt import create_access_token
+from app.auth.keys import load_rsa_keys, reset_keys
 from app.database import Database
 
 
@@ -31,7 +32,7 @@ def jwt_secret(monkeypatch) -> str:
 
 
 @pytest.fixture
-async def client(test_db, jwt_secret, monkeypatch):
+async def client(test_db, jwt_secret, rsa_keys, monkeypatch):
     """Async HTTP client with test database and JWT secret injected.
 
     Patches the ``db`` attribute in every module that imports it so that
@@ -236,22 +237,37 @@ def sample_changes():
 
 
 # ---------------------------------------------------------------------------
+# RSA key fixture for RS256 JWT signing
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def rsa_keys():
+    """Generate and load test RSA keys for JWT signing."""
+    from joserfc.jwk import RSAKey
+    reset_keys()
+    key = RSAKey.generate_key(2048)
+    load_rsa_keys(pem_data=key.as_pem(private=True).decode("utf-8"))
+    yield
+    reset_keys()
+
+
+# ---------------------------------------------------------------------------
 # Auth fixtures — user creation + JWT tokens
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-async def auth_user_a(test_db, jwt_secret):
+async def auth_user_a(test_db, rsa_keys):
     """Create user A and return (user_dict, bearer_token)."""
     user = await test_db.create_user(email="alice@test.com", hashed_password="hash_a", display_name="Alice")
-    token = create_access_token(user_id=user["id"], email=user["email"], secret=jwt_secret)
+    token = create_access_token(user_id=user["id"], email=user["email"])
     return user, token
 
 
 @pytest.fixture
-async def auth_user_b(test_db, jwt_secret):
+async def auth_user_b(test_db, rsa_keys):
     """Create user B and return (user_dict, bearer_token)."""
     user = await test_db.create_user(email="bob@test.com", hashed_password="hash_b", display_name="Bob")
-    token = create_access_token(user_id=user["id"], email=user["email"], secret=jwt_secret)
+    token = create_access_token(user_id=user["id"], email=user["email"])
     return user, token
 
 

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -58,6 +58,7 @@ async def client(test_db, jwt_secret, monkeypatch):
     import app.routers.auth as auth_mod
     import app.routers.oauth as oauth_mod
     import app.routers.google_oauth as google_oauth_mod
+    import app.routers.mcp as mcp_mod
     import app.routers.resumes as resumes_mod
     import app.routers.jobs as jobs_mod
     import app.routers.health as health_mod
@@ -65,7 +66,7 @@ async def client(test_db, jwt_secret, monkeypatch):
     import app.routers.enrichment as enrichment_mod
     import app.main as main_mod
 
-    for mod in (db_module, auth_deps_mod, auth_mod, oauth_mod, google_oauth_mod, resumes_mod, jobs_mod, health_mod, config_mod, enrichment_mod, main_mod):
+    for mod in (db_module, auth_deps_mod, auth_mod, oauth_mod, google_oauth_mod, mcp_mod, resumes_mod, jobs_mod, health_mod, config_mod, enrichment_mod, main_mod):
         if hasattr(mod, "db"):
             monkeypatch.setattr(mod, "db", test_db)
 

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -5,6 +5,8 @@ import copy
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.auth.jwt import create_access_token
+from app.config import settings
 from app.database import Database
 
 
@@ -226,3 +228,37 @@ def sample_changes():
             reason="Already in good order, no change needed",
         ),
     ]
+
+
+# ---------------------------------------------------------------------------
+# Auth fixtures — user creation + JWT tokens
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def auth_user_a(test_db):
+    """Create user A and return (user_dict, bearer_token)."""
+    user = await test_db.create_user(email="alice@test.com", hashed_password="hash_a", display_name="Alice")
+    token = create_access_token(user_id=user["id"], email=user["email"], secret=settings.effective_jwt_secret)
+    return user, token
+
+
+@pytest.fixture
+async def auth_user_b(test_db):
+    """Create user B and return (user_dict, bearer_token)."""
+    user = await test_db.create_user(email="bob@test.com", hashed_password="hash_b", display_name="Bob")
+    token = create_access_token(user_id=user["id"], email=user["email"], secret=settings.effective_jwt_secret)
+    return user, token
+
+
+@pytest.fixture
+def auth_headers_a(auth_user_a):
+    """Authorization headers for user A."""
+    _, token = auth_user_a
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def auth_headers_b(auth_user_b):
+    """Authorization headers for user B."""
+    _, token = auth_user_b
+    return {"Authorization": f"Bearer {token}"}

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -32,12 +32,13 @@ def jwt_secret(monkeypatch) -> str:
 
 
 @pytest.fixture
-async def client(test_db, jwt_secret, rsa_keys, monkeypatch):
+async def client(test_db, jwt_secret, rsa_keys, first_party_client, monkeypatch):
     """Async HTTP client with test database and JWT secret injected.
 
     Patches the ``db`` attribute in every module that imports it so that
     the routers, services **and** the lifespan all talk to the in-memory
-    test database.
+    test database.  The first_party_client fixture seeds the default OAuth
+    client so that authorize/token flows work with DB-backed validation.
     """
     import app.database as db_module
     import app.auth.dependencies as auth_deps_mod
@@ -249,6 +250,21 @@ def rsa_keys():
     load_rsa_keys(pem_data=key.as_pem(private=True).decode("utf-8"))
     yield
     reset_keys()
+
+
+# ---------------------------------------------------------------------------
+# First-party OAuth client fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def first_party_client(test_db):
+    """Seed the first-party OAuth client (normally done by migration)."""
+    await test_db.create_oauth_client(
+        client_id="resume-matcher-web",
+        client_name="Resume Matcher Web",
+        redirect_uris=["http://localhost:3000/callback", "http://127.0.0.1:3000/callback"],
+        grant_types=["authorization_code", "refresh_token"],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -6,7 +6,6 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.auth.jwt import create_access_token
-from app.config import settings
 from app.database import Database
 
 
@@ -24,7 +23,15 @@ async def test_db():
 
 
 @pytest.fixture
-async def client(test_db, monkeypatch):
+def jwt_secret(monkeypatch) -> str:
+    """Patch JWT secret for tests -- shared by client and auth fixtures."""
+    secret = "test-secret-for-tests"
+    monkeypatch.setattr("app.config.settings.jwt_secret_key", secret)
+    return secret
+
+
+@pytest.fixture
+async def client(test_db, jwt_secret, monkeypatch):
     """Async HTTP client with test database and JWT secret injected.
 
     Patches the ``db`` attribute in every module that imports it so that
@@ -46,8 +53,6 @@ async def client(test_db, monkeypatch):
     for mod in (db_module, auth_deps_mod, auth_mod, oauth_mod, google_oauth_mod, resumes_mod, jobs_mod, health_mod, config_mod, enrichment_mod, main_mod):
         if hasattr(mod, "db"):
             monkeypatch.setattr(mod, "db", test_db)
-
-    monkeypatch.setattr("app.config.settings.jwt_secret_key", "test-secret-for-tests")
 
     from app.main import app
     async with AsyncClient(
@@ -235,18 +240,18 @@ def sample_changes():
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-async def auth_user_a(test_db):
+async def auth_user_a(test_db, jwt_secret):
     """Create user A and return (user_dict, bearer_token)."""
     user = await test_db.create_user(email="alice@test.com", hashed_password="hash_a", display_name="Alice")
-    token = create_access_token(user_id=user["id"], email=user["email"], secret=settings.effective_jwt_secret)
+    token = create_access_token(user_id=user["id"], email=user["email"], secret=jwt_secret)
     return user, token
 
 
 @pytest.fixture
-async def auth_user_b(test_db):
+async def auth_user_b(test_db, jwt_secret):
     """Create user B and return (user_dict, bearer_token)."""
     user = await test_db.create_user(email="bob@test.com", hashed_password="hash_b", display_name="Bob")
-    token = create_access_token(user_id=user["id"], email=user["email"], secret=settings.effective_jwt_secret)
+    token = create_access_token(user_id=user["id"], email=user["email"], secret=jwt_secret)
     return user, token
 
 

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -32,14 +32,27 @@ def jwt_secret(monkeypatch) -> str:
 
 
 @pytest.fixture
-async def client(test_db, jwt_secret, rsa_keys, first_party_client, monkeypatch):
+async def client(test_db, jwt_secret, monkeypatch):
     """Async HTTP client with test database and JWT secret injected.
 
     Patches the ``db`` attribute in every module that imports it so that
     the routers, services **and** the lifespan all talk to the in-memory
-    test database.  The first_party_client fixture seeds the default OAuth
-    client so that authorize/token flows work with DB-backed validation.
+    test database.
     """
+    # Load RSA keys for JWT signing (inline to avoid async fixture chain issues)
+    from joserfc.jwk import RSAKey as _RSAKey
+    reset_keys()
+    _key = _RSAKey.generate_key(2048)
+    load_rsa_keys(pem_data=_key.as_pem(private=True).decode("utf-8"))
+
+    # Seed first-party OAuth client (normally done by migration)
+    await test_db.create_oauth_client(
+        client_id="resume-matcher-web",
+        client_name="Resume Matcher Web",
+        redirect_uris=["http://localhost:3000/callback", "http://127.0.0.1:3000/callback"],
+        grant_types=["authorization_code", "refresh_token"],
+    )
+
     import app.database as db_module
     import app.auth.dependencies as auth_deps_mod
     import app.routers.auth as auth_mod

--- a/apps/backend/tests/integration/test_claude_compat.py
+++ b/apps/backend/tests/integration/test_claude_compat.py
@@ -13,14 +13,16 @@ class TestClaudeCompat:
         assert "client_id" in resp.json()
 
     @pytest.mark.anyio
-    async def test_root_authorize_redirects(self, client):
+    async def test_root_authorize_redirects_to_frontend(self, client):
         resp = await client.get(
             "/authorize",
             params={"response_type": "code", "client_id": "test"},
             follow_redirects=False,
         )
-        assert resp.status_code == 307
-        assert "/api/v1/oauth/authorize" in resp.headers["location"]
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert "/login" in location
+        assert "client_id=test" in location
 
     @pytest.mark.anyio
     async def test_root_token_reaches_endpoint(self, client):

--- a/apps/backend/tests/integration/test_claude_compat.py
+++ b/apps/backend/tests/integration/test_claude_compat.py
@@ -1,0 +1,35 @@
+"""Tests for claude.ai compatibility proxy endpoints."""
+import pytest
+
+
+class TestClaudeCompat:
+    @pytest.mark.anyio
+    async def test_root_register_proxies(self, client):
+        resp = await client.post("/register", json={
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+            "client_name": "Claude via root",
+        })
+        assert resp.status_code == 201
+        assert "client_id" in resp.json()
+
+    @pytest.mark.anyio
+    async def test_root_authorize_redirects(self, client):
+        resp = await client.get(
+            "/authorize",
+            params={"response_type": "code", "client_id": "test"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307
+        assert "/api/v1/oauth/authorize" in resp.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_root_token_reaches_endpoint(self, client):
+        resp = await client.post("/token", json={
+            "grant_type": "authorization_code",
+            "code": "invalid",
+            "code_verifier": "test",
+            "client_id": "test",
+            "redirect_uri": "http://localhost/callback",
+        })
+        # Should reach the real token endpoint (400 because code is invalid, not 404)
+        assert resp.status_code == 400

--- a/apps/backend/tests/integration/test_data_isolation.py
+++ b/apps/backend/tests/integration/test_data_isolation.py
@@ -1,0 +1,103 @@
+"""Integration tests for multi-user data isolation."""
+
+import pytest
+
+
+class TestAuthEnforcement:
+    """All data endpoints must return 401 without a Bearer token."""
+
+    PROTECTED_ENDPOINTS = [
+        ("GET", "/api/v1/resumes?resume_id=fake"),
+        ("GET", "/api/v1/resumes/list"),
+        ("GET", "/api/v1/resumes/fake/pdf"),
+        ("DELETE", "/api/v1/resumes/fake"),
+        ("GET", "/api/v1/resumes/fake/job-description"),
+        ("GET", "/api/v1/jobs/fake"),
+        ("GET", "/api/v1/status"),
+        ("POST", "/api/v1/enrichment/analyze/fake"),
+    ]
+
+    @pytest.mark.parametrize("method,path", PROTECTED_ENDPOINTS)
+    async def test_returns_401_without_token(self, client, method, path):
+        resp = await client.request(method, path)
+        assert resp.status_code == 401
+
+
+class TestResumeIsolation:
+    async def test_user_b_cannot_see_user_a_resume(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        _, token_b = auth_user_b
+        headers_a = {"Authorization": f"Bearer {token_a}"}
+        headers_b = {"Authorization": f"Bearer {token_b}"}
+
+        resume = await test_db.create_resume(content="# Secret", user_id=user_a["id"])
+        rid = resume["resume_id"]
+
+        resp = await client.get(f"/api/v1/resumes?resume_id={rid}", headers=headers_a)
+        assert resp.status_code == 200
+
+        resp = await client.get(f"/api/v1/resumes?resume_id={rid}", headers=headers_b)
+        assert resp.status_code == 404
+
+    async def test_list_resumes_only_shows_own(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        user_b, token_b = auth_user_b
+
+        await test_db.create_resume(content="# A1", user_id=user_a["id"])
+        await test_db.create_resume(content="# A2", user_id=user_a["id"])
+        await test_db.create_resume(content="# B1", user_id=user_b["id"])
+
+        resp = await client.get(
+            "/api/v1/resumes/list?include_master=true",
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert len(data) == 2
+
+    async def test_user_b_cannot_delete_user_a_resume(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, _ = auth_user_a
+        _, token_b = auth_user_b
+
+        resume = await test_db.create_resume(content="# A", user_id=user_a["id"])
+
+        resp = await client.delete(
+            f"/api/v1/resumes/{resume['resume_id']}",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert resp.status_code == 404
+
+        still_exists = await test_db.get_resume(resume["resume_id"], user_a["id"])
+        assert still_exists is not None
+
+
+class TestJobIsolation:
+    async def test_user_b_cannot_see_user_a_job(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        _, token_b = auth_user_b
+
+        job = await test_db.create_job(content="JD text", user_id=user_a["id"])
+
+        resp = await client.get(f"/api/v1/jobs/{job['job_id']}", headers={"Authorization": f"Bearer {token_a}"})
+        assert resp.status_code == 200
+
+        resp = await client.get(f"/api/v1/jobs/{job['job_id']}", headers={"Authorization": f"Bearer {token_b}"})
+        assert resp.status_code == 404
+
+
+class TestStatusScoping:
+    async def test_status_returns_user_stats(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        _, token_b = auth_user_b
+
+        await test_db.create_resume(content="# A", user_id=user_a["id"], is_master=True)
+
+        resp = await client.get("/api/v1/status", headers={"Authorization": f"Bearer {token_a}"})
+        assert resp.status_code == 200
+        assert resp.json()["database_stats"]["total_resumes"] == 1
+        assert resp.json()["has_master_resume"] is True
+
+        resp = await client.get("/api/v1/status", headers={"Authorization": f"Bearer {token_b}"})
+        assert resp.status_code == 200
+        assert resp.json()["database_stats"]["total_resumes"] == 0
+        assert resp.json()["has_master_resume"] is False

--- a/apps/backend/tests/integration/test_dcr.py
+++ b/apps/backend/tests/integration/test_dcr.py
@@ -1,0 +1,58 @@
+"""Tests for Dynamic Client Registration (RFC 7591)."""
+import pytest
+
+
+class TestDCR:
+    @pytest.mark.anyio
+    async def test_register_new_client(self, client):
+        resp = await client.post("/api/v1/oauth/register", json={
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+            "client_name": "Claude",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "client_id" in data
+        assert data["client_name"] == "Claude"
+        assert data["token_endpoint_auth_method"] == "none"
+        assert "client_id_issued_at" in data
+
+    @pytest.mark.anyio
+    async def test_register_without_redirect_uris_fails(self, client):
+        resp = await client.post("/api/v1/oauth/register", json={
+            "client_name": "Bad Client",
+        })
+        assert resp.status_code == 422  # validation error
+
+    @pytest.mark.anyio
+    async def test_defaults_auth_method_to_none(self, client):
+        resp = await client.post("/api/v1/oauth/register", json={
+            "redirect_uris": ["https://example.com/callback"],
+        })
+        assert resp.status_code == 201
+        assert resp.json()["token_endpoint_auth_method"] == "none"
+
+
+class TestDBClientValidation:
+    @pytest.mark.anyio
+    async def test_unknown_client_rejected(self, client):
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "x@test.com", "password": "pass",
+            "client_id": "unknown-client",
+            "redirect_uri": "http://evil.com/callback",
+            "code_challenge": "abc",
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_wrong_redirect_uri_rejected(self, client, test_db):
+        await test_db.create_oauth_client(
+            client_id="test-client",
+            redirect_uris=["http://legit.com/callback"],
+        )
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "x@test.com", "password": "pass",
+            "client_id": "test-client",
+            "redirect_uri": "http://evil.com/callback",
+            "code_challenge": "abc",
+        })
+        assert resp.status_code == 400

--- a/apps/backend/tests/integration/test_health_api.py
+++ b/apps/backend/tests/integration/test_health_api.py
@@ -38,7 +38,7 @@ class TestStatusEndpoint:
     @patch("app.routers.health.db")
     @patch("app.routers.health.check_llm_health", new_callable=AsyncMock)
     @patch("app.routers.health.get_llm_config")
-    async def test_status_ready(self, mock_config, mock_health, mock_db, client):
+    async def test_status_ready(self, mock_config, mock_health, mock_db, client, auth_headers_a):
         mock_config.return_value = type("C", (), {"api_key": "sk-test", "provider": "openai"})()
         mock_health.return_value = {"healthy": True}
         mock_db.get_stats = AsyncMock(return_value={
@@ -47,7 +47,7 @@ class TestStatusEndpoint:
             "total_improvements": 0,
             "has_master_resume": True,
         })
-        resp = await client.get("/api/v1/status")
+        resp = await client.get("/api/v1/status", headers=auth_headers_a)
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "ready"
@@ -57,7 +57,7 @@ class TestStatusEndpoint:
     @patch("app.routers.health.db")
     @patch("app.routers.health.check_llm_health", new_callable=AsyncMock)
     @patch("app.routers.health.get_llm_config")
-    async def test_status_setup_required(self, mock_config, mock_health, mock_db, client):
+    async def test_status_setup_required(self, mock_config, mock_health, mock_db, client, auth_headers_a):
         mock_config.return_value = type("C", (), {"api_key": "", "provider": "openai"})()
         mock_health.return_value = {"healthy": False}
         mock_db.get_stats = AsyncMock(return_value={
@@ -66,7 +66,7 @@ class TestStatusEndpoint:
             "total_improvements": 0,
             "has_master_resume": False,
         })
-        resp = await client.get("/api/v1/status")
+        resp = await client.get("/api/v1/status", headers=auth_headers_a)
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "setup_required"

--- a/apps/backend/tests/integration/test_jobs_api.py
+++ b/apps/backend/tests/integration/test_jobs_api.py
@@ -7,7 +7,7 @@ class TestJobUpload:
     """POST /api/v1/jobs/upload"""
 
     @patch("app.routers.jobs.db")
-    async def test_upload_single_job(self, mock_db, client):
+    async def test_upload_single_job(self, mock_db, client, auth_headers_a):
         mock_db.create_job = AsyncMock(return_value={
             "job_id": "job-123",
             "content": "Senior Engineer at TechCorp",
@@ -16,34 +16,34 @@ class TestJobUpload:
         resp = await client.post("/api/v1/jobs/upload", json={
             "job_descriptions": ["Senior Engineer at TechCorp"],
             "resume_id": None,
-        })
+        }, headers=auth_headers_a)
         assert resp.status_code == 200
         data = resp.json()
         assert data["message"] == "data successfully processed"
         assert len(data["job_id"]) == 1
 
     @patch("app.routers.jobs.db")
-    async def test_upload_multiple_jobs(self, mock_db, client):
+    async def test_upload_multiple_jobs(self, mock_db, client, auth_headers_a):
         mock_db.create_job = AsyncMock(side_effect=[
             {"job_id": f"job-{i}", "content": f"JD {i}", "created_at": "2026-01-01T00:00:00Z"}
             for i in range(3)
         ])
         resp = await client.post("/api/v1/jobs/upload", json={
             "job_descriptions": ["JD 1", "JD 2", "JD 3"],
-        })
+        }, headers=auth_headers_a)
         assert resp.status_code == 200
         assert len(resp.json()["job_id"]) == 3
 
-    async def test_upload_empty_list_returns_400(self, client):
+    async def test_upload_empty_list_returns_400(self, client, auth_headers_a):
         resp = await client.post("/api/v1/jobs/upload", json={
             "job_descriptions": [],
-        })
+        }, headers=auth_headers_a)
         assert resp.status_code == 400
 
-    async def test_upload_empty_string_returns_400(self, client):
+    async def test_upload_empty_string_returns_400(self, client, auth_headers_a):
         resp = await client.post("/api/v1/jobs/upload", json={
             "job_descriptions": ["  "],
-        })
+        }, headers=auth_headers_a)
         assert resp.status_code == 400
 
 
@@ -51,18 +51,18 @@ class TestGetJob:
     """GET /api/v1/jobs/{job_id}"""
 
     @patch("app.routers.jobs.db")
-    async def test_get_existing_job(self, mock_db, client):
+    async def test_get_existing_job(self, mock_db, client, auth_headers_a):
         mock_db.get_job = AsyncMock(return_value={
             "job_id": "job-123",
             "content": "Engineer role",
             "created_at": "2026-01-01T00:00:00Z",
         })
-        resp = await client.get("/api/v1/jobs/job-123")
+        resp = await client.get("/api/v1/jobs/job-123", headers=auth_headers_a)
         assert resp.status_code == 200
         assert resp.json()["job_id"] == "job-123"
 
     @patch("app.routers.jobs.db")
-    async def test_get_nonexistent_job_returns_404(self, mock_db, client):
+    async def test_get_nonexistent_job_returns_404(self, mock_db, client, auth_headers_a):
         mock_db.get_job = AsyncMock(return_value=None)
-        resp = await client.get("/api/v1/jobs/nonexistent")
+        resp = await client.get("/api/v1/jobs/nonexistent", headers=auth_headers_a)
         assert resp.status_code == 404

--- a/apps/backend/tests/integration/test_mcp.py
+++ b/apps/backend/tests/integration/test_mcp.py
@@ -1,0 +1,124 @@
+"""Tests for MCP endpoint (JSON-RPC 2.0 over Streamable HTTP)."""
+import json
+import pytest
+
+
+def _jsonrpc(method: str, params: dict | None = None, msg_id: int = 1) -> dict:
+    msg = {"jsonrpc": "2.0", "method": method, "id": msg_id}
+    if params:
+        msg["params"] = params
+    return msg
+
+
+class TestMCPInitialize:
+    @pytest.mark.anyio
+    async def test_initialize_without_auth(self, client):
+        resp = await client.post("/mcp", json=_jsonrpc("initialize", {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"},
+        }))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "result" in data
+        result = data["result"]
+        assert "serverInfo" in result
+        assert "capabilities" in result
+        assert result["capabilities"].get("tools") is not None
+
+    @pytest.mark.anyio
+    async def test_initialize_returns_session_id(self, client):
+        resp = await client.post("/mcp", json=_jsonrpc("initialize", {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"},
+        }))
+        assert "mcp-session-id" in resp.headers
+
+
+class TestMCPAuth:
+    @pytest.mark.anyio
+    async def test_tools_list_requires_auth(self, client):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/list"))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "error" in data
+        assert data["error"]["code"] == -32600
+
+    @pytest.mark.anyio
+    async def test_tools_list_with_auth(self, client, auth_headers_a):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/list"), headers=auth_headers_a)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "result" in data
+        tools = data["result"]["tools"]
+        assert len(tools) > 0
+        tool_names = [t["name"] for t in tools]
+        assert "list_resumes" in tool_names
+        assert "get_resume" in tool_names
+        assert "get_status" in tool_names
+
+
+class TestMCPToolCalls:
+    @pytest.mark.anyio
+    async def test_list_resumes_empty(self, client, auth_headers_a):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "list_resumes",
+            "arguments": {},
+        }), headers=auth_headers_a)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "result" in data
+        content = data["result"]["content"]
+        assert isinstance(content, list)
+        assert content[0]["type"] == "text"
+
+    @pytest.mark.anyio
+    async def test_list_resumes_returns_user_data(self, client, auth_headers_a, auth_user_a, test_db, sample_resume):
+        user_a, _ = auth_user_a
+        await test_db.create_resume(
+            content=json.dumps(sample_resume), user_id=user_a["id"], title="My Resume"
+        )
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "list_resumes",
+            "arguments": {},
+        }), headers=auth_headers_a)
+        data = resp.json()
+        content = data["result"]["content"]
+        assert "My Resume" in content[0]["text"]
+
+    @pytest.mark.anyio
+    async def test_tool_call_isolation(self, client, auth_headers_a, auth_headers_b, auth_user_a, auth_user_b, test_db, sample_resume):
+        user_a, _ = auth_user_a
+        await test_db.create_resume(
+            content=json.dumps(sample_resume), user_id=user_a["id"], title="A's Resume"
+        )
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "list_resumes",
+            "arguments": {},
+        }), headers=auth_headers_b)
+        data = resp.json()
+        content = data["result"]["content"]
+        assert "A's Resume" not in content[0]["text"]
+
+    @pytest.mark.anyio
+    async def test_unknown_tool_returns_error(self, client, auth_headers_a):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "nonexistent_tool",
+            "arguments": {},
+        }), headers=auth_headers_a)
+        data = resp.json()
+        assert "error" in data
+
+    @pytest.mark.anyio
+    async def test_get_status(self, client, auth_headers_a):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "get_status",
+            "arguments": {},
+        }), headers=auth_headers_a)
+        data = resp.json()
+        assert "result" in data
+        text = data["result"]["content"][0]["text"]
+        stats = json.loads(text)
+        assert "total_resumes" in stats

--- a/apps/backend/tests/integration/test_regenerate_endpoints.py
+++ b/apps/backend/tests/integration/test_regenerate_endpoints.py
@@ -7,6 +7,8 @@ from pydantic import ValidationError
 from app.routers import enrichment as enrichment_router
 from app.schemas.enrichment import RegenerateItemInput, RegenerateRequest, RegeneratedItem
 
+FAKE_USER = {"id": "test-user-id", "email": "test@test.com"}
+
 
 class TestRegenerateSchemas(unittest.TestCase):
     def test_regenerate_request_instruction_max_length(self) -> None:
@@ -91,7 +93,7 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
                 AsyncMock(return_value=skills_item),
             ) as mock_regenerate_skills,
         ):
-            response = await enrichment_router.regenerate_items(request)
+            response = await enrichment_router.regenerate_items(request, user=FAKE_USER)
 
         self.assertEqual(
             [item.item_id for item in response.regenerated_items],
@@ -148,7 +150,7 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
                 AsyncMock(return_value=skills_item),
             ),
         ):
-            response = await enrichment_router.regenerate_items(request)
+            response = await enrichment_router.regenerate_items(request, user=FAKE_USER)
 
         self.assertEqual([item.item_id for item in response.regenerated_items], ["skills"])
         self.assertEqual([err.item_id for err in response.errors], ["exp_0"])
@@ -189,11 +191,11 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
         ]
 
         with patch.object(enrichment_router, "db", mock_db):
-            result = await enrichment_router.apply_regenerated_items(resume_id, regenerated_items)
+            result = await enrichment_router.apply_regenerated_items(resume_id, regenerated_items, user=FAKE_USER)
 
         self.assertEqual(result["updated_items"], 1)
 
-        update_payload = mock_db.update_resume.call_args.args[1]
+        update_payload = mock_db.update_resume.call_args.args[2]
         updated = update_payload["processed_data"]
 
         self.assertEqual(updated["workExperience"][0]["description"], ["Keep me"])
@@ -227,11 +229,11 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
         ]
 
         with patch.object(enrichment_router, "db", mock_db):
-            result = await enrichment_router.apply_regenerated_items(resume_id, regenerated_items)
+            result = await enrichment_router.apply_regenerated_items(resume_id, regenerated_items, user=FAKE_USER)
 
         self.assertEqual(result["updated_items"], 1)
 
-        updated = mock_db.update_resume.call_args.args[1]["processed_data"]
+        updated = mock_db.update_resume.call_args.args[2]["processed_data"]
         self.assertEqual(updated["workExperience"][0]["description"], ["Bullet A"])
         self.assertEqual(updated["workExperience"][1]["description"], ["Bullet B (rewritten)"])
 
@@ -262,7 +264,7 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(enrichment_router, "db", mock_db):
             with self.assertRaises(HTTPException) as ctx:
-                await enrichment_router.apply_regenerated_items(resume_id, regenerated_items)
+                await enrichment_router.apply_regenerated_items(resume_id, regenerated_items, user=FAKE_USER)
 
         self.assertEqual(ctx.exception.status_code, 409)
         mock_db.update_resume.assert_not_called()
@@ -287,10 +289,10 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
         mock_db_additional.update_resume = AsyncMock(return_value=None)
 
         with patch.object(enrichment_router, "db", mock_db_additional):
-            result = await enrichment_router.apply_regenerated_items(resume_id, [base_item])
+            result = await enrichment_router.apply_regenerated_items(resume_id, [base_item], user=FAKE_USER)
 
         self.assertEqual(result["updated_items"], 1)
-        updated = mock_db_additional.update_resume.call_args.args[1]["processed_data"]
+        updated = mock_db_additional.update_resume.call_args.args[2]["processed_data"]
         self.assertEqual(updated["additional"]["technicalSkills"], ["Python", "TypeScript"])
 
         # legacy technicalSkills path
@@ -299,10 +301,10 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
         mock_db_legacy.update_resume = AsyncMock(return_value=None)
 
         with patch.object(enrichment_router, "db", mock_db_legacy):
-            result = await enrichment_router.apply_regenerated_items(resume_id, [base_item])
+            result = await enrichment_router.apply_regenerated_items(resume_id, [base_item], user=FAKE_USER)
 
         self.assertEqual(result["updated_items"], 1)
-        updated = mock_db_legacy.update_resume.call_args.args[1]["processed_data"]
+        updated = mock_db_legacy.update_resume.call_args.args[2]["processed_data"]
         self.assertEqual(updated["technicalSkills"], ["Python", "TypeScript"])
 
     async def test_apply_regenerated_skills_fails_when_no_supported_path_exists(self) -> None:
@@ -324,7 +326,7 @@ class TestRegenerateEndpoints(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(enrichment_router, "db", mock_db):
             with self.assertRaises(HTTPException) as ctx:
-                await enrichment_router.apply_regenerated_items(resume_id, regenerated_items)
+                await enrichment_router.apply_regenerated_items(resume_id, regenerated_items, user=FAKE_USER)
 
         self.assertEqual(ctx.exception.status_code, 409)
         mock_db.update_resume.assert_not_called()

--- a/apps/backend/tests/integration/test_resume_api.py
+++ b/apps/backend/tests/integration/test_resume_api.py
@@ -30,9 +30,9 @@ class TestGetResume:
     """GET /api/v1/resumes?resume_id=..."""
 
     @patch("app.routers.resumes.db")
-    async def test_fetch_existing_resume(self, mock_db, client, mock_resume_record):
+    async def test_fetch_existing_resume(self, mock_db, client, auth_headers_a, mock_resume_record):
         mock_db.get_resume = AsyncMock(return_value=mock_resume_record)
-        resp = await client.get("/api/v1/resumes", params={"resume_id": "res-123"})
+        resp = await client.get("/api/v1/resumes", params={"resume_id": "res-123"}, headers=auth_headers_a)
         assert resp.status_code == 200
         data = resp.json()["data"]
         assert data["resume_id"] == "res-123"
@@ -40,9 +40,9 @@ class TestGetResume:
         assert data["processed_resume"]["summary"] != ""
 
     @patch("app.routers.resumes.db")
-    async def test_fetch_nonexistent_returns_404(self, mock_db, client):
+    async def test_fetch_nonexistent_returns_404(self, mock_db, client, auth_headers_a):
         mock_db.get_resume = AsyncMock(return_value=None)
-        resp = await client.get("/api/v1/resumes", params={"resume_id": "nonexistent"})
+        resp = await client.get("/api/v1/resumes", params={"resume_id": "nonexistent"}, headers=auth_headers_a)
         assert resp.status_code == 404
 
 
@@ -50,24 +50,24 @@ class TestListResumes:
     """GET /api/v1/resumes/list"""
 
     @patch("app.routers.resumes.db")
-    async def test_list_excludes_master_by_default(self, mock_db, client):
+    async def test_list_excludes_master_by_default(self, mock_db, client, auth_headers_a):
         mock_db.list_resumes = AsyncMock(return_value=[
             {"resume_id": "master", "is_master": True, "created_at": "2026-01-01", "updated_at": "2026-01-01"},
             {"resume_id": "tailored-1", "is_master": False, "created_at": "2026-01-02", "updated_at": "2026-01-02"},
         ])
-        resp = await client.get("/api/v1/resumes/list")
+        resp = await client.get("/api/v1/resumes/list", headers=auth_headers_a)
         assert resp.status_code == 200
         data = resp.json()["data"]
         assert len(data) == 1
         assert data[0]["resume_id"] == "tailored-1"
 
     @patch("app.routers.resumes.db")
-    async def test_list_includes_master_when_requested(self, mock_db, client):
+    async def test_list_includes_master_when_requested(self, mock_db, client, auth_headers_a):
         mock_db.list_resumes = AsyncMock(return_value=[
             {"resume_id": "master", "is_master": True, "created_at": "2026-01-01", "updated_at": "2026-01-01"},
             {"resume_id": "tailored-1", "is_master": False, "created_at": "2026-01-02", "updated_at": "2026-01-02"},
         ])
-        resp = await client.get("/api/v1/resumes/list", params={"include_master": True})
+        resp = await client.get("/api/v1/resumes/list", params={"include_master": True}, headers=auth_headers_a)
         assert resp.status_code == 200
         data = resp.json()["data"]
         assert len(data) == 2
@@ -77,15 +77,15 @@ class TestDeleteResume:
     """DELETE /api/v1/resumes/{resume_id}"""
 
     @patch("app.routers.resumes.db")
-    async def test_delete_existing_resume(self, mock_db, client):
+    async def test_delete_existing_resume(self, mock_db, client, auth_headers_a):
         mock_db.delete_resume = AsyncMock(return_value=True)
-        resp = await client.delete("/api/v1/resumes/res-123")
+        resp = await client.delete("/api/v1/resumes/res-123", headers=auth_headers_a)
         assert resp.status_code == 200
 
     @patch("app.routers.resumes.db")
-    async def test_delete_nonexistent_returns_404(self, mock_db, client):
+    async def test_delete_nonexistent_returns_404(self, mock_db, client, auth_headers_a):
         mock_db.delete_resume = AsyncMock(return_value=False)
-        resp = await client.delete("/api/v1/resumes/nonexistent")
+        resp = await client.delete("/api/v1/resumes/nonexistent", headers=auth_headers_a)
         assert resp.status_code == 404
 
 
@@ -93,16 +93,16 @@ class TestUpdateTitle:
     """PATCH /api/v1/resumes/{resume_id}/title"""
 
     @patch("app.routers.resumes.db")
-    async def test_update_title(self, mock_db, client, mock_resume_record):
+    async def test_update_title(self, mock_db, client, auth_headers_a, mock_resume_record):
         mock_db.get_resume = AsyncMock(return_value=mock_resume_record)
         mock_db.update_resume = AsyncMock(return_value={**mock_resume_record, "title": "New Title"})
-        resp = await client.patch("/api/v1/resumes/res-123/title", json={"title": "New Title"})
+        resp = await client.patch("/api/v1/resumes/res-123/title", json={"title": "New Title"}, headers=auth_headers_a)
         assert resp.status_code == 200
 
     @patch("app.routers.resumes.db")
-    async def test_update_title_nonexistent_returns_404(self, mock_db, client):
+    async def test_update_title_nonexistent_returns_404(self, mock_db, client, auth_headers_a):
         mock_db.get_resume = AsyncMock(return_value=None)
-        resp = await client.patch("/api/v1/resumes/nonexistent/title", json={"title": "X"})
+        resp = await client.patch("/api/v1/resumes/nonexistent/title", json={"title": "X"}, headers=auth_headers_a)
         assert resp.status_code == 404
 
 
@@ -110,10 +110,10 @@ class TestUpdateCoverLetter:
     """PATCH /api/v1/resumes/{resume_id}/cover-letter"""
 
     @patch("app.routers.resumes.db")
-    async def test_update_cover_letter(self, mock_db, client, mock_resume_record):
+    async def test_update_cover_letter(self, mock_db, client, auth_headers_a, mock_resume_record):
         mock_db.get_resume = AsyncMock(return_value=mock_resume_record)
         mock_db.update_resume = AsyncMock(return_value={**mock_resume_record, "cover_letter": "Dear hiring manager..."})
-        resp = await client.patch("/api/v1/resumes/res-123/cover-letter", json={"content": "Dear hiring manager..."})
+        resp = await client.patch("/api/v1/resumes/res-123/cover-letter", json={"content": "Dear hiring manager..."}, headers=auth_headers_a)
         assert resp.status_code == 200
 
 
@@ -121,10 +121,10 @@ class TestUpdateOutreachMessage:
     """PATCH /api/v1/resumes/{resume_id}/outreach-message"""
 
     @patch("app.routers.resumes.db")
-    async def test_update_outreach(self, mock_db, client, mock_resume_record):
+    async def test_update_outreach(self, mock_db, client, auth_headers_a, mock_resume_record):
         mock_db.get_resume = AsyncMock(return_value=mock_resume_record)
         mock_db.update_resume = AsyncMock(return_value={**mock_resume_record, "outreach_message": "Hi, I saw your posting..."})
-        resp = await client.patch("/api/v1/resumes/res-123/outreach-message", json={"content": "Hi, I saw your posting..."})
+        resp = await client.patch("/api/v1/resumes/res-123/outreach-message", json={"content": "Hi, I saw your posting..."}, headers=auth_headers_a)
         assert resp.status_code == 200
 
 
@@ -133,19 +133,19 @@ class TestRetryProcessing:
 
     @patch("app.routers.resumes.parse_resume_to_json", new_callable=AsyncMock)
     @patch("app.routers.resumes.db")
-    async def test_retry_successful(self, mock_db, mock_parse, client, mock_resume_record, sample_resume):
+    async def test_retry_successful(self, mock_db, mock_parse, client, auth_headers_a, mock_resume_record, sample_resume):
         failed_record = {**mock_resume_record, "processing_status": "failed"}
         mock_db.get_resume = AsyncMock(return_value=failed_record)
         mock_parse.return_value = sample_resume
         mock_db.update_resume = AsyncMock(return_value={**failed_record, "processing_status": "ready", "processed_data": sample_resume})
-        resp = await client.post("/api/v1/resumes/res-123/retry-processing")
+        resp = await client.post("/api/v1/resumes/res-123/retry-processing", headers=auth_headers_a)
         assert resp.status_code == 200
         data = resp.json()
         assert data["processing_status"] == "ready"
 
     @patch("app.routers.resumes.db")
-    async def test_retry_not_failed_returns_400(self, mock_db, client, mock_resume_record):
+    async def test_retry_not_failed_returns_400(self, mock_db, client, auth_headers_a, mock_resume_record):
         # processing_status is "ready", not "failed"
         mock_db.get_resume = AsyncMock(return_value=mock_resume_record)
-        resp = await client.post("/api/v1/resumes/res-123/retry-processing")
+        resp = await client.post("/api/v1/resumes/res-123/retry-processing", headers=auth_headers_a)
         assert resp.status_code == 400

--- a/apps/backend/tests/integration/test_well_known_endpoints.py
+++ b/apps/backend/tests/integration/test_well_known_endpoints.py
@@ -1,0 +1,42 @@
+"""Tests for .well-known metadata endpoints."""
+import pytest
+
+
+class TestJWKS:
+    @pytest.mark.anyio
+    async def test_jwks_returns_public_key(self, client):
+        resp = await client.get("/.well-known/jwks.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "keys" in data
+        assert len(data["keys"]) == 1
+        key = data["keys"][0]
+        assert key["kty"] == "RSA"
+        assert key["alg"] == "RS256"
+        assert key["use"] == "sig"
+        assert "kid" in key
+        assert "n" in key
+        assert "e" in key
+        assert "d" not in key
+
+
+class TestProtectedResourceMetadata:
+    @pytest.mark.anyio
+    async def test_returns_required_fields(self, client):
+        resp = await client.get("/.well-known/oauth-protected-resource")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["resource"] == "http://test"
+        assert data["authorization_servers"] == ["http://test"]
+        assert data["bearer_methods_supported"] == ["header"]
+
+
+class TestOAuthServerMetadata:
+    @pytest.mark.anyio
+    async def test_includes_registration_and_jwks(self, client):
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        data = resp.json()
+        assert data["registration_endpoint"] is not None
+        assert "register" in data["registration_endpoint"]
+        assert data["jwks_uri"] is not None
+        assert "jwks" in data["jwks_uri"]

--- a/apps/backend/tests/unit/test_database.py
+++ b/apps/backend/tests/unit/test_database.py
@@ -12,117 +12,123 @@ async def db():
     await database.close()
 
 
+@pytest.fixture
+async def user(db):
+    return await db.create_user(email="test@test.com", hashed_password="hash")
+
+
 @pytest.mark.asyncio
-async def test_create_and_get_resume(db):
-    resume = await db.create_resume(content="# Test", content_type="md")
+async def test_create_and_get_resume(db, user):
+    resume = await db.create_resume(content="# Test", content_type="md", user_id=user["id"])
     assert resume["resume_id"]
     assert resume["content"] == "# Test"
     assert resume["processing_status"] == "pending"
-    fetched = await db.get_resume(resume["resume_id"])
+    fetched = await db.get_resume(resume["resume_id"], user["id"])
     assert fetched is not None
     assert fetched["resume_id"] == resume["resume_id"]
 
 
 @pytest.mark.asyncio
-async def test_get_resume_not_found(db):
-    assert await db.get_resume("nonexistent") is None
+async def test_get_resume_not_found(db, user):
+    assert await db.get_resume("nonexistent", user["id"]) is None
 
 
 @pytest.mark.asyncio
-async def test_update_resume(db):
-    resume = await db.create_resume(content="# Old")
-    updated = await db.update_resume(resume["resume_id"], {"content": "# New"})
+async def test_update_resume(db, user):
+    resume = await db.create_resume(content="# Old", user_id=user["id"])
+    updated = await db.update_resume(resume["resume_id"], user["id"], {"content": "# New"})
     assert updated["content"] == "# New"
 
 
 @pytest.mark.asyncio
-async def test_update_resume_not_found(db):
+async def test_update_resume_not_found(db, user):
     with pytest.raises(ValueError, match="Resume not found"):
-        await db.update_resume("nonexistent", {"content": "x"})
+        await db.update_resume("nonexistent", user["id"], {"content": "x"})
 
 
 @pytest.mark.asyncio
-async def test_delete_resume(db):
-    resume = await db.create_resume(content="# Delete me")
-    assert await db.delete_resume(resume["resume_id"]) is True
-    assert await db.get_resume(resume["resume_id"]) is None
+async def test_delete_resume(db, user):
+    resume = await db.create_resume(content="# Delete me", user_id=user["id"])
+    assert await db.delete_resume(resume["resume_id"], user["id"]) is True
+    assert await db.get_resume(resume["resume_id"], user["id"]) is None
 
 
 @pytest.mark.asyncio
-async def test_delete_resume_not_found(db):
-    assert await db.delete_resume("nonexistent") is False
+async def test_delete_resume_not_found(db, user):
+    assert await db.delete_resume("nonexistent", user["id"]) is False
 
 
 @pytest.mark.asyncio
-async def test_list_resumes(db):
-    await db.create_resume(content="# A")
-    await db.create_resume(content="# B")
-    assert len(await db.list_resumes()) == 2
+async def test_list_resumes(db, user):
+    await db.create_resume(content="# A", user_id=user["id"])
+    await db.create_resume(content="# B", user_id=user["id"])
+    assert len(await db.list_resumes(user["id"])) == 2
 
 
 @pytest.mark.asyncio
-async def test_master_resume_atomic(db):
-    r1 = await db.create_resume_atomic_master(content="# First")
+async def test_master_resume_atomic(db, user):
+    r1 = await db.create_resume_atomic_master(content="# First", user_id=user["id"])
     assert r1["is_master"] is True
-    r2 = await db.create_resume_atomic_master(content="# Second")
+    r2 = await db.create_resume_atomic_master(content="# Second", user_id=user["id"])
     assert r2["is_master"] is False
-    master = await db.get_master_resume()
+    master = await db.get_master_resume(user["id"])
     assert master["resume_id"] == r1["resume_id"]
 
 
 @pytest.mark.asyncio
-async def test_set_master_resume(db):
-    r1 = await db.create_resume_atomic_master(content="# First")
-    r2 = await db.create_resume(content="# Second")
-    assert await db.set_master_resume(r2["resume_id"]) is True
-    master = await db.get_master_resume()
+async def test_set_master_resume(db, user):
+    r1 = await db.create_resume_atomic_master(content="# First", user_id=user["id"])
+    r2 = await db.create_resume(content="# Second", user_id=user["id"])
+    assert await db.set_master_resume(r2["resume_id"], user["id"]) is True
+    master = await db.get_master_resume(user["id"])
     assert master["resume_id"] == r2["resume_id"]
-    old = await db.get_resume(r1["resume_id"])
+    old = await db.get_resume(r1["resume_id"], user["id"])
     assert old["is_master"] is False
 
 
 @pytest.mark.asyncio
-async def test_create_and_get_job(db):
-    job = await db.create_job(content="Backend engineer needed")
+async def test_create_and_get_job(db, user):
+    job = await db.create_job(content="Backend engineer needed", user_id=user["id"])
     assert job["job_id"]
-    fetched = await db.get_job(job["job_id"])
+    fetched = await db.get_job(job["job_id"], user["id"])
     assert fetched["content"] == "Backend engineer needed"
 
 
 @pytest.mark.asyncio
-async def test_update_job(db):
-    job = await db.create_job(content="Original")
-    updated = await db.update_job(job["job_id"], {"content": "Updated"})
+async def test_update_job(db, user):
+    job = await db.create_job(content="Original", user_id=user["id"])
+    updated = await db.update_job(job["job_id"], user["id"], {"content": "Updated"})
     assert updated["content"] == "Updated"
 
 
 @pytest.mark.asyncio
-async def test_create_and_get_improvement(db):
+async def test_create_and_get_improvement(db, user):
     imp = await db.create_improvement(
         original_resume_id="orig-1", tailored_resume_id="tail-1",
         job_id="job-1", improvements=[{"suggestion": "Add Python", "lineNumber": 5}],
+        user_id=user["id"],
     )
     assert imp["request_id"]
-    fetched = await db.get_improvement_by_tailored_resume("tail-1")
+    fetched = await db.get_improvement_by_tailored_resume("tail-1", user["id"])
     assert fetched is not None
     assert fetched["job_id"] == "job-1"
 
 
 @pytest.mark.asyncio
-async def test_get_stats(db):
-    await db.create_resume(content="# Test", is_master=True)
-    await db.create_job(content="Job desc")
-    stats = await db.get_stats()
+async def test_get_stats(db, user):
+    await db.create_resume(content="# Test", is_master=True, user_id=user["id"])
+    await db.create_job(content="Job desc", user_id=user["id"])
+    stats = await db.get_stats(user["id"])
     assert stats["total_resumes"] == 1
     assert stats["total_jobs"] == 1
     assert stats["has_master_resume"] is True
 
 
 @pytest.mark.asyncio
-async def test_reset_database(db):
-    await db.create_resume(content="# Test")
-    await db.create_job(content="Job")
+async def test_reset_database(db, user):
+    await db.create_resume(content="# Test", user_id=user["id"])
+    await db.create_job(content="Job", user_id=user["id"])
     await db.reset_database()
-    stats = await db.get_stats()
+    stats = await db.get_stats(user["id"])
     assert stats["total_resumes"] == 0
     assert stats["total_jobs"] == 0

--- a/apps/backend/tests/unit/test_database_user_scoping.py
+++ b/apps/backend/tests/unit/test_database_user_scoping.py
@@ -1,0 +1,145 @@
+"""Tests for user-scoped database operations."""
+
+import pytest
+from app.database import Database
+
+
+@pytest.fixture
+async def db():
+    database = Database("sqlite+aiosqlite://")
+    await database.init()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def user_a(db):
+    return await db.create_user(email="a@test.com", hashed_password="hash_a")
+
+
+@pytest.fixture
+async def user_b(db):
+    return await db.create_user(email="b@test.com", hashed_password="hash_b")
+
+
+class TestResumeScoping:
+    @pytest.mark.asyncio
+    async def test_create_resume_requires_user_id(self, db, user_a):
+        resume = await db.create_resume(content="# Resume", user_id=user_a["id"])
+        assert resume["resume_id"]
+
+    @pytest.mark.asyncio
+    async def test_get_resume_scoped_to_user(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# A", user_id=user_a["id"])
+        assert await db.get_resume(resume["resume_id"], user_id=user_a["id"]) is not None
+        assert await db.get_resume(resume["resume_id"], user_id=user_b["id"]) is None
+
+    @pytest.mark.asyncio
+    async def test_list_resumes_scoped_to_user(self, db, user_a, user_b):
+        await db.create_resume(content="# A", user_id=user_a["id"])
+        await db.create_resume(content="# B", user_id=user_b["id"])
+        a_resumes = await db.list_resumes(user_id=user_a["id"])
+        assert len(a_resumes) == 1
+
+    @pytest.mark.asyncio
+    async def test_update_resume_scoped_to_user(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# A", user_id=user_a["id"])
+        updated = await db.update_resume(resume["resume_id"], user_id=user_a["id"], updates={"content": "# Updated"})
+        assert updated["content"] == "# Updated"
+        with pytest.raises(ValueError):
+            await db.update_resume(resume["resume_id"], user_id=user_b["id"], updates={"content": "# Hack"})
+
+    @pytest.mark.asyncio
+    async def test_delete_resume_scoped_to_user(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# A", user_id=user_a["id"])
+        assert await db.delete_resume(resume["resume_id"], user_id=user_b["id"]) is False
+        assert await db.delete_resume(resume["resume_id"], user_id=user_a["id"]) is True
+
+    @pytest.mark.asyncio
+    async def test_get_master_resume_scoped(self, db, user_a, user_b):
+        await db.create_resume(content="# A Master", user_id=user_a["id"], is_master=True)
+        await db.create_resume(content="# B Master", user_id=user_b["id"], is_master=True)
+        a_master = await db.get_master_resume(user_id=user_a["id"])
+        assert "A Master" in a_master["content"]
+        b_master = await db.get_master_resume(user_id=user_b["id"])
+        assert "B Master" in b_master["content"]
+
+    @pytest.mark.asyncio
+    async def test_set_master_resume_scoped(self, db, user_a, user_b):
+        r1 = await db.create_resume(content="# A1", user_id=user_a["id"], is_master=True)
+        r2 = await db.create_resume(content="# A2", user_id=user_a["id"])
+        rb = await db.create_resume(content="# B1", user_id=user_b["id"], is_master=True)
+        assert await db.set_master_resume(r2["resume_id"], user_id=user_a["id"]) is True
+        b_master = await db.get_master_resume(user_id=user_b["id"])
+        assert b_master["resume_id"] == rb["resume_id"]
+        assert b_master["is_master"] is True
+
+    @pytest.mark.asyncio
+    async def test_create_resume_atomic_master_scoped(self, db, user_a, user_b):
+        r_a = await db.create_resume_atomic_master(content="# A", user_id=user_a["id"])
+        assert r_a["is_master"] is True
+        r_b = await db.create_resume_atomic_master(content="# B", user_id=user_b["id"])
+        assert r_b["is_master"] is True
+
+
+class TestJobScoping:
+    @pytest.mark.asyncio
+    async def test_create_job_with_user_id(self, db, user_a):
+        job = await db.create_job(content="Job desc", user_id=user_a["id"])
+        assert job["job_id"]
+
+    @pytest.mark.asyncio
+    async def test_get_job_scoped(self, db, user_a, user_b):
+        job = await db.create_job(content="Job desc", user_id=user_a["id"])
+        assert await db.get_job(job["job_id"], user_id=user_a["id"]) is not None
+        assert await db.get_job(job["job_id"], user_id=user_b["id"]) is None
+
+    @pytest.mark.asyncio
+    async def test_update_job_scoped(self, db, user_a, user_b):
+        job = await db.create_job(content="Job desc", user_id=user_a["id"])
+        updated = await db.update_job(job["job_id"], user_id=user_a["id"], updates={"content": "New"})
+        assert updated["content"] == "New"
+        assert await db.update_job(job["job_id"], user_id=user_b["id"], updates={"content": "Hack"}) is None
+
+
+class TestImprovementScoping:
+    @pytest.mark.asyncio
+    async def test_create_improvement_with_user_id(self, db, user_a):
+        resume = await db.create_resume(content="# R", user_id=user_a["id"])
+        tailored = await db.create_resume(content="# T", user_id=user_a["id"])
+        job = await db.create_job(content="JD", user_id=user_a["id"])
+        imp = await db.create_improvement(
+            original_resume_id=resume["resume_id"],
+            tailored_resume_id=tailored["resume_id"],
+            job_id=job["job_id"],
+            improvements=[],
+            user_id=user_a["id"],
+        )
+        assert imp["request_id"]
+
+    @pytest.mark.asyncio
+    async def test_get_improvement_scoped(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# R", user_id=user_a["id"])
+        tailored = await db.create_resume(content="# T", user_id=user_a["id"])
+        job = await db.create_job(content="JD", user_id=user_a["id"])
+        await db.create_improvement(
+            original_resume_id=resume["resume_id"],
+            tailored_resume_id=tailored["resume_id"],
+            job_id=job["job_id"],
+            improvements=[],
+            user_id=user_a["id"],
+        )
+        assert await db.get_improvement_by_tailored_resume(tailored["resume_id"], user_id=user_a["id"]) is not None
+        assert await db.get_improvement_by_tailored_resume(tailored["resume_id"], user_id=user_b["id"]) is None
+
+
+class TestStatsScoping:
+    @pytest.mark.asyncio
+    async def test_stats_scoped_to_user(self, db, user_a, user_b):
+        await db.create_resume(content="# A", user_id=user_a["id"])
+        await db.create_resume(content="# B1", user_id=user_b["id"])
+        await db.create_resume(content="# B2", user_id=user_b["id"])
+        stats_a = await db.get_stats(user_id=user_a["id"])
+        assert stats_a["total_resumes"] == 1
+        stats_b = await db.get_stats(user_id=user_b["id"])
+        assert stats_b["total_resumes"] == 2

--- a/apps/backend/tests/unit/test_jwt.py
+++ b/apps/backend/tests/unit/test_jwt.py
@@ -1,63 +1,81 @@
-"""Tests for JWT access token creation and verification."""
+"""Tests for RS256 JWT access token creation and verification."""
 
 import time
 
 import pytest
 from app.auth.jwt import create_access_token, verify_access_token
+from app.auth.keys import load_rsa_keys, reset_keys
 
-TEST_SECRET = "test-secret-key-for-unit-tests-only"
+
+@pytest.fixture(autouse=True)
+def _rsa_keys():
+    """Load test RSA keys for all JWT tests."""
+    from joserfc.jwk import RSAKey
+    reset_keys()
+    key = RSAKey.generate_key(2048)
+    load_rsa_keys(pem_data=key.as_pem(private=True).decode("utf-8"))
+    yield
+    reset_keys()
 
 
 class TestJWT:
     def test_create_returns_string(self) -> None:
-        token = create_access_token(
-            user_id="user-123", email="test@example.com", secret=TEST_SECRET
-        )
+        token = create_access_token(user_id="user-123", email="test@example.com")
         assert isinstance(token, str)
         assert len(token) > 0
 
     def test_verify_valid_token(self) -> None:
-        token = create_access_token(
-            user_id="user-123", email="test@example.com", secret=TEST_SECRET
-        )
-        claims = verify_access_token(token, secret=TEST_SECRET)
+        token = create_access_token(user_id="user-123", email="test@example.com")
+        claims = verify_access_token(token)
         assert claims["sub"] == "user-123"
         assert claims["email"] == "test@example.com"
 
     def test_verify_expired_token(self) -> None:
         token = create_access_token(
-            user_id="user-123",
-            email="test@example.com",
-            secret=TEST_SECRET,
-            expires_minutes=0,
+            user_id="user-123", email="test@example.com", expires_minutes=-1
         )
-        time.sleep(1)
         with pytest.raises(ValueError, match="[Ee]xpired"):
-            verify_access_token(token, secret=TEST_SECRET)
+            verify_access_token(token)
 
-    def test_verify_invalid_signature(self) -> None:
-        token = create_access_token(
-            user_id="user-123", email="test@example.com", secret=TEST_SECRET
-        )
+    def test_verify_wrong_key(self) -> None:
+        """Token signed with one key should not verify with another."""
+        from joserfc.jwk import RSAKey
+        token = create_access_token(user_id="user-123", email="test@example.com")
+        # Load a different key
+        reset_keys()
+        other_key = RSAKey.generate_key(2048)
+        load_rsa_keys(pem_data=other_key.as_pem(private=True).decode("utf-8"))
         with pytest.raises(ValueError):
-            verify_access_token(token, secret="wrong-secret")
+            verify_access_token(token)
 
     def test_verify_malformed_token(self) -> None:
         with pytest.raises(ValueError):
-            verify_access_token("not.a.jwt", secret=TEST_SECRET)
+            verify_access_token("not.a.jwt")
 
     def test_token_contains_iss_claim(self) -> None:
-        token = create_access_token(
-            user_id="user-123", email="test@example.com", secret=TEST_SECRET
-        )
-        claims = verify_access_token(token, secret=TEST_SECRET)
+        token = create_access_token(user_id="user-123", email="test@example.com")
+        claims = verify_access_token(token)
         assert claims["iss"] == "resume-matcher"
 
     def test_token_contains_exp_and_iat(self) -> None:
-        token = create_access_token(
-            user_id="user-123", email="test@example.com", secret=TEST_SECRET
-        )
-        claims = verify_access_token(token, secret=TEST_SECRET)
+        token = create_access_token(user_id="user-123", email="test@example.com")
+        claims = verify_access_token(token)
         assert "exp" in claims
         assert "iat" in claims
         assert claims["exp"] > claims["iat"]
+
+    def test_token_header_has_kid_and_rs256(self) -> None:
+        from joserfc import jwt as jose_jwt
+        from app.auth.keys import get_kid, get_public_key
+        token = create_access_token(user_id="u1", email="e@x.com")
+        obj = jose_jwt.decode(token, get_public_key())
+        assert obj.header["alg"] == "RS256"
+        assert obj.header["kid"] == get_kid()
+
+    def test_tampered_token_rejected(self) -> None:
+        token = create_access_token(user_id="u1", email="e@x.com")
+        parts = token.split(".")
+        parts[1] = parts[1][:-4] + "XXXX"
+        tampered = ".".join(parts)
+        with pytest.raises(ValueError):
+            verify_access_token(tampered)

--- a/apps/backend/tests/unit/test_oauth_clients_db.py
+++ b/apps/backend/tests/unit/test_oauth_clients_db.py
@@ -1,0 +1,39 @@
+"""Tests for OAuthClient database operations."""
+import pytest
+
+
+class TestOAuthClientCRUD:
+    @pytest.mark.anyio
+    async def test_create_oauth_client(self, test_db):
+        client = await test_db.create_oauth_client(
+            client_name="Test App",
+            redirect_uris=["http://localhost:3000/callback"],
+        )
+        assert client["client_id"] is not None
+        assert client["client_name"] == "Test App"
+        assert client["token_endpoint_auth_method"] == "none"
+        assert client["is_active"] is True
+
+    @pytest.mark.anyio
+    async def test_get_oauth_client(self, test_db):
+        created = await test_db.create_oauth_client(
+            client_name="App",
+            redirect_uris=["http://example.com/cb"],
+        )
+        fetched = await test_db.get_oauth_client(created["client_id"])
+        assert fetched is not None
+        assert fetched["client_id"] == created["client_id"]
+
+    @pytest.mark.anyio
+    async def test_get_nonexistent_returns_none(self, test_db):
+        result = await test_db.get_oauth_client("nonexistent")
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_create_with_explicit_id(self, test_db):
+        client = await test_db.create_oauth_client(
+            client_id="resume-matcher-web",
+            client_name="Resume Matcher Web",
+            redirect_uris=["http://localhost:3000/callback"],
+        )
+        assert client["client_id"] == "resume-matcher-web"

--- a/apps/backend/tests/unit/test_rsa_keys.py
+++ b/apps/backend/tests/unit/test_rsa_keys.py
@@ -1,0 +1,151 @@
+"""Tests for RSA key management module."""
+
+from pathlib import Path
+
+import pytest
+
+from app.auth.keys import (
+    compute_kid,
+    get_jwks,
+    get_kid,
+    get_private_key,
+    get_public_key,
+    load_rsa_keys,
+    reset_keys,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_keys():
+    """Reset key cache before and after each test."""
+    reset_keys()
+    yield
+    reset_keys()
+
+
+class TestAccessorsBeforeLoad:
+    def test_get_private_key_raises(self):
+        with pytest.raises(RuntimeError, match="not loaded"):
+            get_private_key()
+
+    def test_get_public_key_raises(self):
+        with pytest.raises(RuntimeError, match="not loaded"):
+            get_public_key()
+
+    def test_get_kid_raises(self):
+        with pytest.raises(RuntimeError, match="not loaded"):
+            get_kid()
+
+
+class TestAutoGeneration:
+    def test_generates_key_pair(self):
+        load_rsa_keys()
+        assert get_private_key() is not None
+        assert get_public_key() is not None
+        assert isinstance(get_kid(), str)
+        assert len(get_kid()) > 0
+
+    def test_key_is_2048_bit(self):
+        import base64
+        load_rsa_keys()
+        d = get_private_key().as_dict(private=True)
+        n_bytes = base64.urlsafe_b64decode(d["n"] + "==")
+        assert len(n_bytes) == 256  # 2048 bits = 256 bytes
+
+
+class TestCaching:
+    def test_second_load_is_noop(self):
+        load_rsa_keys()
+        kid1 = get_kid()
+        load_rsa_keys()  # should not regenerate
+        assert get_kid() == kid1
+
+    def test_reset_clears_cache(self):
+        load_rsa_keys()
+        reset_keys()
+        with pytest.raises(RuntimeError, match="not loaded"):
+            get_private_key()
+
+
+class TestLoadFromPEM:
+    def test_malformed_pem_raises_valueerror(self):
+        with pytest.raises(ValueError, match="Failed to load RSA key from PEM data"):
+            load_rsa_keys(pem_data="not-a-valid-pem")
+
+    def test_load_from_pem_data(self):
+        from joserfc.jwk import RSAKey
+        key = RSAKey.generate_key(2048)
+        pem = key.as_pem(private=True).decode("utf-8")
+        load_rsa_keys(pem_data=pem)
+        assert get_private_key().thumbprint() == key.thumbprint()
+
+
+class TestLoadFromFile:
+    def test_load_from_existing_file(self, tmp_path: Path):
+        from joserfc.jwk import RSAKey
+        key = RSAKey.generate_key(2048)
+        pem_file = tmp_path / "test_key.pem"
+        pem_file.write_text(key.as_pem(private=True).decode("utf-8"))
+        load_rsa_keys(key_file=str(pem_file))
+        assert get_private_key().thumbprint() == key.thumbprint()
+
+    def test_auto_generate_saves_to_file(self, tmp_path: Path):
+        pem_file = tmp_path / "auto_key.pem"
+        assert not pem_file.exists()
+        load_rsa_keys(key_file=str(pem_file))
+        assert pem_file.exists()
+        content = pem_file.read_text()
+        assert "PRIVATE KEY" in content
+
+    def test_generated_file_has_restricted_perms(self, tmp_path: Path):
+        pem_file = tmp_path / "secure_key.pem"
+        load_rsa_keys(key_file=str(pem_file))
+        assert pem_file.stat().st_mode & 0o777 == 0o600
+
+
+class TestPriority:
+    def test_pem_data_over_file(self, tmp_path: Path):
+        from joserfc.jwk import RSAKey
+        key1 = RSAKey.generate_key(2048)
+        key2 = RSAKey.generate_key(2048)
+        pem_file = tmp_path / "key.pem"
+        pem_file.write_text(key2.as_pem(private=True).decode("utf-8"))
+        load_rsa_keys(
+            pem_data=key1.as_pem(private=True).decode("utf-8"),
+            key_file=str(pem_file),
+        )
+        assert get_private_key().thumbprint() == key1.thumbprint()
+
+
+class TestJWKS:
+    def test_jwks_format(self):
+        load_rsa_keys()
+        jwks = get_jwks()
+        assert "keys" in jwks
+        assert len(jwks["keys"]) == 1
+        key = jwks["keys"][0]
+        assert key["kty"] == "RSA"
+        assert key["alg"] == "RS256"
+        assert key["use"] == "sig"
+        assert "kid" in key
+        assert "n" in key
+        assert "e" in key
+
+    def test_jwks_excludes_private_components(self):
+        load_rsa_keys()
+        key = get_jwks()["keys"][0]
+        for private_field in ("d", "p", "q", "dp", "dq", "qi"):
+            assert private_field not in key
+
+
+class TestKIDDeterminism:
+    def test_same_key_same_kid(self):
+        from joserfc.jwk import RSAKey
+        key = RSAKey.generate_key(2048)
+        pem = key.as_pem(private=True).decode("utf-8")
+        load_rsa_keys(pem_data=pem)
+        kid1 = get_kid()
+        reset_keys()
+        load_rsa_keys(pem_data=pem)
+        kid2 = get_kid()
+        assert kid1 == kid2

--- a/apps/frontend/app/(auth)/login/page.tsx
+++ b/apps/frontend/app/(auth)/login/page.tsx
@@ -16,6 +16,15 @@ function LoginContent() {
   const [providers, setProviders] = useState<string[]>(['credentials']);
   const [googleLoading, setGoogleLoading] = useState(false);
 
+  // Third-party OAuth flow: detect params from authorize redirect
+  const oauthClientId = params.get('client_id');
+  const oauthRedirectUri = params.get('redirect_uri');
+  const oauthCodeChallenge = params.get('code_challenge');
+  const oauthCodeChallengeMethod = params.get('code_challenge_method') || 'S256';
+  const oauthState = params.get('state');
+  const oauthScope = params.get('scope');
+  const isThirdPartyOAuth = !!(oauthClientId && oauthRedirectUri && oauthCodeChallenge);
+
   const errorParam = params.get('error');
   const errorMessage =
     errorParam === 'account_exists'
@@ -27,9 +36,14 @@ function LoginContent() {
         : null;
 
   useEffect(() => {
-    startLogin()
-      .then(({ codeChallenge, state }) => setPkce({ codeChallenge, state }))
-      .catch(() => setInitFailed(true));
+    if (isThirdPartyOAuth) {
+      // Use OAuth params from URL instead of generating our own PKCE
+      setPkce({ codeChallenge: oauthCodeChallenge!, state: oauthState || '' });
+    } else {
+      startLogin()
+        .then(({ codeChallenge, state }) => setPkce({ codeChallenge, state }))
+        .catch(() => setInitFailed(true));
+    }
 
     apiFetch('/auth/providers')
       .then((r) => r.json())
@@ -106,7 +120,14 @@ function LoginContent() {
           </>
         )}
 
-        <LoginForm codeChallenge={pkce.codeChallenge} state={pkce.state} />
+        <LoginForm
+          codeChallenge={pkce.codeChallenge}
+          state={pkce.state}
+          oauthClientId={isThirdPartyOAuth ? oauthClientId! : undefined}
+          oauthRedirectUri={isThirdPartyOAuth ? oauthRedirectUri! : undefined}
+          oauthCodeChallengeMethod={isThirdPartyOAuth ? oauthCodeChallengeMethod : undefined}
+          oauthScope={isThirdPartyOAuth ? oauthScope || undefined : undefined}
+        />
       </div>
     </div>
   );

--- a/apps/frontend/components/auth/login-form.tsx
+++ b/apps/frontend/components/auth/login-form.tsx
@@ -49,20 +49,12 @@ export function LoginForm({
           state,
           ...(oauthScope ? { scope: oauthScope } : {}),
         }),
-        redirect: 'manual',
       });
 
-      if (resp.type === 'opaqueredirect' || resp.status === 303) {
-        const location = resp.headers.get('location');
-        if (location) {
-          window.location.href = location;
-          return;
-        }
-      }
+      const data = await resp.json().catch(() => ({}));
 
-      // If we got a redirect response that fetch followed
-      if (resp.redirected && resp.url) {
-        window.location.href = resp.url;
+      if (resp.ok && data.redirect_url) {
+        window.location.href = data.redirect_url;
         return;
       }
 
@@ -70,7 +62,6 @@ export function LoginForm({
       if (resp.status === 401) {
         setError(t('auth.invalidCredentials'));
       } else {
-        const data = await resp.json().catch(() => ({}));
         setError(data.detail || t('auth.loginFailed'));
       }
     } catch {

--- a/apps/frontend/components/auth/login-form.tsx
+++ b/apps/frontend/components/auth/login-form.tsx
@@ -7,9 +7,20 @@ import { useTranslations } from '@/lib/i18n/translations';
 interface LoginFormProps {
   codeChallenge: string;
   state: string;
+  oauthClientId?: string;
+  oauthRedirectUri?: string;
+  oauthCodeChallengeMethod?: string;
+  oauthScope?: string;
 }
 
-export function LoginForm({ codeChallenge, state }: LoginFormProps) {
+export function LoginForm({
+  codeChallenge,
+  state,
+  oauthClientId,
+  oauthRedirectUri,
+  oauthCodeChallengeMethod,
+  oauthScope,
+}: LoginFormProps) {
   const { t } = useTranslations();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -22,7 +33,8 @@ export function LoginForm({ codeChallenge, state }: LoginFormProps) {
     setLoading(true);
 
     try {
-      const redirectUri = `${window.location.origin}/callback`;
+      const clientId = oauthClientId || 'resume-matcher-web';
+      const redirectUri = oauthRedirectUri || `${window.location.origin}/callback`;
       const resp = await apiFetch('/oauth/authorize', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -30,11 +42,12 @@ export function LoginForm({ codeChallenge, state }: LoginFormProps) {
         body: JSON.stringify({
           email,
           password,
-          client_id: 'resume-matcher-web',
+          client_id: clientId,
           redirect_uri: redirectUri,
           code_challenge: codeChallenge,
-          code_challenge_method: 'S256',
+          code_challenge_method: oauthCodeChallengeMethod || 'S256',
           state,
+          ...(oauthScope ? { scope: oauthScope } : {}),
         }),
         redirect: 'manual',
       });

--- a/apps/frontend/lib/api/config.ts
+++ b/apps/frontend/lib/api/config.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from './client';
+import { apiFetch, authFetch } from './client';
 
 // Supported LLM providers
 export type LLMProvider = 'openai' | 'anthropic' | 'openrouter' | 'gemini' | 'deepseek' | 'ollama';
@@ -110,7 +110,7 @@ export async function testLlmConnection(config?: LLMConfigUpdate): Promise<LLMHe
 
 // Fetch system status
 export async function fetchSystemStatus(): Promise<SystemStatus> {
-  const res = await apiFetch('/status', { credentials: 'include' });
+  const res = await authFetch('/status');
 
   if (!res.ok) {
     throw new Error(`Failed to fetch system status (status ${res.status}).`);

--- a/apps/frontend/lib/api/enrichment.ts
+++ b/apps/frontend/lib/api/enrichment.ts
@@ -2,7 +2,7 @@
  * API functions for AI-powered resume enrichment.
  */
 
-import { apiFetch, apiPost } from './client';
+import { authFetch } from './client';
 
 // Types matching backend schemas
 
@@ -50,9 +50,8 @@ export interface EnhancementPreview {
  * Returns items with weak descriptions and clarifying questions.
  */
 export async function analyzeResume(resumeId: string): Promise<AnalysisResponse> {
-  const res = await apiFetch(`/enrichment/analyze/${resumeId}`, {
+  const res = await authFetch(`/enrichment/analyze/${resumeId}`, {
     method: 'POST',
-    credentials: 'include',
   });
 
   if (!res.ok) {
@@ -70,9 +69,10 @@ export async function generateEnhancements(
   resumeId: string,
   answers: AnswerInput[]
 ): Promise<EnhancementPreview> {
-  const res = await apiPost('/enrichment/enhance', {
-    resume_id: resumeId,
-    answers,
+  const res = await authFetch('/enrichment/enhance', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ resume_id: resumeId, answers }),
   });
 
   if (!res.ok) {
@@ -90,8 +90,10 @@ export async function applyEnhancements(
   resumeId: string,
   enhancements: EnhancedDescription[]
 ): Promise<{ message: string; updated_items: number }> {
-  const res = await apiPost(`/enrichment/apply/${resumeId}`, {
-    enhancements,
+  const res = await authFetch(`/enrichment/apply/${resumeId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ enhancements }),
   });
 
   if (!res.ok) {
@@ -149,7 +151,11 @@ export interface RegenerateResponse {
  * Uses AI to rewrite content addressing user's concerns.
  */
 export async function regenerateItems(request: RegenerateRequest): Promise<RegenerateResponse> {
-  const res = await apiPost('/enrichment/regenerate', request);
+  const res = await authFetch('/enrichment/regenerate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+  });
 
   if (!res.ok) {
     const data = await res.json().catch(() => ({}));
@@ -166,7 +172,11 @@ export async function applyRegeneratedItems(
   resumeId: string,
   regeneratedItems: RegeneratedItem[]
 ): Promise<{ message: string; updated_items: number }> {
-  const res = await apiPost(`/enrichment/apply-regenerated/${resumeId}`, regeneratedItems);
+  const res = await authFetch(`/enrichment/apply-regenerated/${resumeId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(regeneratedItems),
+  });
 
   if (!res.ok) {
     const data = await res.json().catch(() => ({}));

--- a/apps/frontend/lib/api/resume.ts
+++ b/apps/frontend/lib/api/resume.ts
@@ -2,7 +2,7 @@ import { ImprovedResult } from '@/components/common/resume_previewer_context';
 import type { ResumeData } from '@/components/dashboard/resume-component';
 import { type TemplateSettings } from '@/lib/types/template-settings';
 import { type Locale } from '@/i18n/config';
-import { API_BASE, apiPost, apiPatch, apiDelete, apiFetch } from './client';
+import { API_BASE, authFetch } from './client';
 
 // Matches backend schemas/models.py ResumeData
 interface ProcessedResume {
@@ -114,7 +114,15 @@ async function postImprove(
 ): Promise<ImprovedResult> {
   let response: Response;
   try {
-    response = await apiPost(endpoint, payload, 240_000);
+    response = await authFetch(
+      endpoint,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      },
+      240_000
+    );
   } catch (networkError) {
     console.error(`Network error during ${endpoint}:`, networkError);
     throw networkError;
@@ -139,9 +147,10 @@ export async function uploadJobDescriptions(
   descriptions: string[],
   resumeId: string
 ): Promise<string> {
-  const res = await apiPost('/jobs/upload', {
-    job_descriptions: descriptions,
-    resume_id: resumeId,
+  const res = await authFetch('/jobs/upload', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ job_descriptions: descriptions, resume_id: resumeId }),
   });
   if (!res.ok) throw new Error(`Upload failed with status ${res.status}`);
   const data = await res.json();
@@ -183,7 +192,7 @@ export async function confirmImproveResume(
 
 /** Fetches a raw resume record for previewing the original upload */
 export async function fetchResume(resumeId: string): Promise<ResumeResponse['data']> {
-  const res = await apiFetch(`/resumes?resume_id=${encodeURIComponent(resumeId)}`);
+  const res = await authFetch(`/resumes?resume_id=${encodeURIComponent(resumeId)}`);
   if (!res.ok) {
     throw new Error(`Failed to load resume (status ${res.status}).`);
   }
@@ -194,7 +203,7 @@ export async function fetchResume(resumeId: string): Promise<ResumeResponse['dat
 }
 
 export async function fetchResumeList(includeMaster = false): Promise<ResumeListItem[]> {
-  const res = await apiFetch(`/resumes/list?include_master=${includeMaster ? 'true' : 'false'}`);
+  const res = await authFetch(`/resumes/list?include_master=${includeMaster ? 'true' : 'false'}`);
   if (!res.ok) {
     throw new Error(`Failed to load resumes list (status ${res.status}).`);
   }
@@ -206,7 +215,11 @@ export async function updateResume(
   resumeId: string,
   resumeData: ProcessedResume
 ): Promise<ResumeResponse['data']> {
-  const res = await apiPatch(`/resumes/${encodeURIComponent(resumeId)}`, resumeData);
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(resumeData),
+  });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to update resume (status ${res.status}): ${text}`);
@@ -257,7 +270,7 @@ export async function downloadResumePdf(
   locale?: Locale
 ): Promise<Blob> {
   const url = getResumePdfUrl(resumeId, settings, locale);
-  const res = await apiFetch(url);
+  const res = await authFetch(url);
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to download resume (status ${res.status}): ${text}`);
@@ -267,7 +280,7 @@ export async function downloadResumePdf(
 
 /** Deletes a resume by ID */
 export async function deleteResume(resumeId: string): Promise<void> {
-  const res = await apiDelete(`/resumes/${encodeURIComponent(resumeId)}`);
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}`, { method: 'DELETE' });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to delete resume (status ${res.status}): ${text}`);
@@ -276,7 +289,11 @@ export async function deleteResume(resumeId: string): Promise<void> {
 
 /** Updates the cover letter for a resume */
 export async function updateCoverLetter(resumeId: string, content: string): Promise<void> {
-  const res = await apiPatch(`/resumes/${encodeURIComponent(resumeId)}/cover-letter`, { content });
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}/cover-letter`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
+  });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to update cover letter (status ${res.status}): ${text}`);
@@ -285,8 +302,10 @@ export async function updateCoverLetter(resumeId: string, content: string): Prom
 
 /** Updates the outreach message for a resume */
 export async function updateOutreachMessage(resumeId: string, content: string): Promise<void> {
-  const res = await apiPatch(`/resumes/${encodeURIComponent(resumeId)}/outreach-message`, {
-    content,
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}/outreach-message`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content }),
   });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
@@ -296,7 +315,11 @@ export async function updateOutreachMessage(resumeId: string, content: string): 
 
 /** Renames a resume by updating its title */
 export async function renameResume(resumeId: string, title: string): Promise<void> {
-  const res = await apiPatch(`/resumes/${encodeURIComponent(resumeId)}/title`, { title });
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}/title`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to rename resume (status ${res.status}): ${text}`);
@@ -323,7 +346,7 @@ export async function downloadCoverLetterPdf(
   locale?: Locale
 ): Promise<Blob> {
   const url = getCoverLetterPdfUrl(resumeId, pageSize, locale);
-  const res = await apiFetch(url);
+  const res = await authFetch(url);
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to download cover letter (status ${res.status}): ${text}`);
@@ -333,7 +356,11 @@ export async function downloadCoverLetterPdf(
 
 /** Generates a cover letter on-demand for a tailored resume */
 export async function generateCoverLetter(resumeId: string): Promise<string> {
-  const res = await apiPost(`/resumes/${encodeURIComponent(resumeId)}/generate-cover-letter`, {});
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}/generate-cover-letter`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to generate cover letter (status ${res.status}): ${text}`);
@@ -344,7 +371,11 @@ export async function generateCoverLetter(resumeId: string): Promise<string> {
 
 /** Generates an outreach message on-demand for a tailored resume */
 export async function generateOutreachMessage(resumeId: string): Promise<string> {
-  const res = await apiPost(`/resumes/${encodeURIComponent(resumeId)}/generate-outreach`, {});
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}/generate-outreach`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to generate outreach message (status ${res.status}): ${text}`);
@@ -355,7 +386,11 @@ export async function generateOutreachMessage(resumeId: string): Promise<string>
 
 /** Retries AI processing for a failed resume */
 export async function retryProcessing(resumeId: string): Promise<ResumeUploadResponse> {
-  const res = await apiPost(`/resumes/${encodeURIComponent(resumeId)}/retry-processing`, {});
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}/retry-processing`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to retry processing (status ${res.status}): ${text}`);
@@ -367,7 +402,7 @@ export async function retryProcessing(resumeId: string): Promise<ResumeUploadRes
 export async function fetchJobDescription(
   resumeId: string
 ): Promise<{ job_id: string; content: string }> {
-  const res = await apiFetch(`/resumes/${encodeURIComponent(resumeId)}/job-description`);
+  const res = await authFetch(`/resumes/${encodeURIComponent(resumeId)}/job-description`);
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     throw new Error(`Failed to fetch job description (status ${res.status}): ${text}`);

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -28,6 +28,27 @@ const nextConfig: NextConfig = {
         source: '/openapi.json',
         destination: `${BACKEND_ORIGIN}/openapi.json`,
       },
+      // MCP + OAuth 2.1 discovery and claude.ai compat proxies
+      {
+        source: '/.well-known/:path*',
+        destination: `${BACKEND_ORIGIN}/.well-known/:path*`,
+      },
+      {
+        source: '/mcp',
+        destination: `${BACKEND_ORIGIN}/mcp`,
+      },
+      {
+        source: '/register',
+        destination: `${BACKEND_ORIGIN}/register`,
+      },
+      {
+        source: '/token',
+        destination: `${BACKEND_ORIGIN}/token`,
+      },
+      {
+        source: '/authorize',
+        destination: `${BACKEND_ORIGIN}/authorize`,
+      },
     ];
   },
 };

--- a/docs/plans/2026-04-02-m2-user-authentication.md
+++ b/docs/plans/2026-04-02-m2-user-authentication.md
@@ -1,0 +1,3054 @@
+# M2: User Authentication -- OAuth 2.1 Authorization Server
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a full OAuth 2.1 authorization server with email/password authentication, JWT tokens, and PKCE -- serving as both the app's auth system and the future MCP auth provider.
+
+**Architecture:** Unified auth path -- the first-party Next.js SPA uses the same OAuth 2.1 authorization code + PKCE flow as future third-party clients (MCP, Google OAuth). No separate login-to-token shortcut. FastAPI-native endpoints with joserfc for JWT operations and authlib utilities for PKCE verification. DB-backed refresh tokens with family-based rotation and reuse detection. Access tokens in JS memory only, refresh token as httpOnly cookie.
+
+**Tech Stack:** FastAPI, joserfc (JWT), authlib (PKCE utilities), argon2-cffi (password hashing), SQLAlchemy 2.0 async, Next.js 16 + React 19
+
+---
+
+## Decision Log
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | Unified OAuth 2.1 auth path (no dual codepaths) | Prior Reactive Resume experience showed dual auth paths are a maintenance nightmare |
+| 2 | DB-backed refresh tokens with family-based reuse detection | OAuth 2.1 requires rotation + reuse detection, needs DB state anyway |
+| 3 | In-memory access token + httpOnly refresh cookie | XSS can't steal what's not persisted; cookie handles persistence |
+| 4 | FastAPI-native endpoints + joserfc + authlib PKCE utilities | authlib's server framework targets sync Flask/Django; fighting it into async FastAPI adds complexity |
+| 5 | No server-side sessions | Credentials posted directly to authorize endpoint; M3 uses Google's state parameter |
+| 6 | Hardcoded first-party client, DCR deferred to M5 | YAGNI -- DCR design depends on MCP's specific requirements |
+| 7 | HS256 JWT signing | Single server, no public key distribution needed; upgrade to RS256 in M5 if needed |
+| 8 | 15-min access token, 7-day refresh token | Industry standard; 401 includes WWW-Authenticate: Bearer (required for claude.ai) |
+| 9 | Auth built but not enforced on existing routes | M2 builds auth; M4 wires it into routes. Clean separation. |
+
+---
+
+## File Map
+
+```text
+apps/backend/
+  app/
+    auth/                          # CREATE: auth module
+      __init__.py
+      constants.py                 # Token lifetimes, first-party client config
+      password.py                  # argon2id hash/verify
+      jwt.py                       # joserfc create/verify access tokens
+      pkce.py                      # S256 code_challenge verification
+      dependencies.py              # FastAPI Depends: get_current_user, get_optional_user
+    config.py                      # MODIFY: add JWT_SECRET_KEY, auth settings
+    models.py                      # MODIFY: add AuthorizationCode, RefreshToken
+    database.py                    # MODIFY: add user/auth CRUD operations
+    main.py                        # MODIFY: register new routers
+    routers/
+      __init__.py                  # MODIFY: export new routers
+      auth.py                      # CREATE: /auth/register, /auth/me
+      oauth.py                     # CREATE: /oauth/authorize, /oauth/token, /oauth/revoke, /.well-known/*
+    schemas/
+      auth.py                      # CREATE: auth request/response schemas
+  alembic/versions/
+    xxxx_add_auth_tables.py        # CREATE: migration for auth_codes + refresh_tokens
+  tests/
+    unit/
+      test_password.py             # CREATE
+      test_jwt.py                  # CREATE
+      test_pkce.py                 # CREATE
+      test_auth_database.py        # CREATE
+    integration/
+      test_register_api.py         # CREATE
+      test_oauth_flow_api.py       # CREATE
+      test_auth_me_api.py          # CREATE
+
+apps/frontend/
+  app/
+    (auth)/                        # CREATE: auth route group
+      login/page.tsx
+      register/page.tsx
+      callback/page.tsx
+  lib/
+    auth/                          # CREATE: auth utilities
+      pkce.ts
+      oauth.ts
+      context.tsx
+  components/
+    auth/                          # CREATE: auth UI components
+      login-form.tsx
+      register-form.tsx
+      user-menu.tsx
+  middleware.ts                    # CREATE: route protection
+```
+
+---
+
+### Task 1: Add Dependencies
+
+**Files:**
+- Modify: `apps/backend/pyproject.toml`
+
+**Step 1: Add auth dependencies**
+
+Add after `python-dotenv`:
+
+```toml
+    "authlib==1.6.0",
+    "joserfc==1.1.1",
+    "argon2-cffi==24.1.0",
+```
+
+**Step 2: Install**
+
+```bash
+cd apps/backend && uv sync
+```
+
+**Step 3: Verify imports**
+
+```bash
+cd apps/backend && uv run python -c "import authlib; import joserfc; import argon2; print('OK')"
+```
+
+Expected: `OK`
+
+**Step 4: Commit**
+
+```bash
+git add apps/backend/pyproject.toml apps/backend/uv.lock
+git commit -m "feat(m2): add authlib, joserfc, argon2-cffi dependencies"
+```
+
+---
+
+### Task 2: Auth Constants and Config
+
+**Files:**
+- Create: `apps/backend/app/auth/__init__.py`
+- Create: `apps/backend/app/auth/constants.py`
+- Modify: `apps/backend/app/config.py`
+
+**Step 1: Create auth module**
+
+```python
+# apps/backend/app/auth/__init__.py
+```
+
+(empty file)
+
+**Step 2: Create constants**
+
+```python
+# apps/backend/app/auth/constants.py
+"""OAuth 2.1 and authentication constants."""
+
+# First-party client (the Next.js SPA)
+FIRST_PARTY_CLIENT_ID = "resume-matcher-web"
+FIRST_PARTY_REDIRECT_URIS = [
+    "http://localhost:3000/callback",
+    "http://127.0.0.1:3000/callback",
+]
+
+# Token lifetimes
+ACCESS_TOKEN_EXPIRE_MINUTES = 15
+REFRESH_TOKEN_EXPIRE_DAYS = 7
+AUTHORIZATION_CODE_EXPIRE_MINUTES = 10
+
+# OAuth 2.1 scopes (minimal for now)
+SUPPORTED_SCOPES = {"openid", "profile", "email"}
+```
+
+**Step 3: Add JWT settings to config.py**
+
+Add to the `Settings` class in `apps/backend/app/config.py`, after the `database_url` field:
+
+```python
+    # Authentication
+    jwt_secret_key: str = ""
+    frontend_origin: str = "http://localhost:3000"
+```
+
+Add a property to validate the secret:
+
+```python
+    @property
+    def effective_jwt_secret(self) -> str:
+        """JWT secret key -- required for auth endpoints."""
+        if not self.jwt_secret_key:
+            raise RuntimeError(
+                "JWT_SECRET_KEY is required. Set it in .env or environment."
+            )
+        return self.jwt_secret_key
+```
+
+**Step 4: Update FIRST_PARTY_REDIRECT_URIS to use config**
+
+The constants file uses hardcoded localhost URIs. The authorize endpoint will also accept `settings.frontend_origin + "/callback"` at runtime.
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/auth/ apps/backend/app/config.py
+git commit -m "feat(m2): add auth constants and JWT config settings"
+```
+
+---
+
+### Task 3: Auth Models + Alembic Migration
+
+**Files:**
+- Modify: `apps/backend/app/models.py`
+- Create: `apps/backend/alembic/versions/xxxx_add_auth_tables.py` (via autogenerate)
+- Create: `apps/backend/tests/unit/test_auth_models.py`
+
+**Step 1: Write failing test**
+
+```python
+# apps/backend/tests/unit/test_auth_models.py
+"""Tests for auth-related ORM models."""
+
+import pytest
+from app.models import AuthorizationCode, Base, RefreshToken
+
+
+class TestAuthModels:
+    def test_authorization_code_table_name(self) -> None:
+        assert AuthorizationCode.__tablename__ == "authorization_codes"
+
+    def test_refresh_token_table_name(self) -> None:
+        assert RefreshToken.__tablename__ == "refresh_tokens"
+
+    def test_auth_tables_in_metadata(self) -> None:
+        table_names = set(Base.metadata.tables.keys())
+        assert "authorization_codes" in table_names
+        assert "refresh_tokens" in table_names
+
+    def test_authorization_code_has_user_fk(self) -> None:
+        fks = {
+            fk.target_fullname
+            for col in AuthorizationCode.__table__.columns
+            for fk in col.foreign_keys
+        }
+        assert "users.id" in fks
+
+    def test_refresh_token_has_user_fk(self) -> None:
+        fks = {
+            fk.target_fullname
+            for col in RefreshToken.__table__.columns
+            for fk in col.foreign_keys
+        }
+        assert "users.id" in fks
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_auth_models.py -v
+```
+
+Expected: FAIL -- `ImportError: cannot import name 'AuthorizationCode' from 'app.models'`
+
+**Step 3: Add models to models.py**
+
+Add after the `Improvement` class:
+
+```python
+class AuthorizationCode(Base):
+    __tablename__ = "authorization_codes"
+    code_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
+    client_id: Mapped[str] = mapped_column(String(255))
+    redirect_uri: Mapped[str] = mapped_column(String(2048))
+    code_challenge: Mapped[str] = mapped_column(String(128))
+    scope: Mapped[str | None] = mapped_column(String(500))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    used_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+class RefreshToken(Base):
+    __tablename__ = "refresh_tokens"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    token_hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
+    family_id: Mapped[str] = mapped_column(String(36), index=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+```
+
+**Step 4: Run test to verify it passes**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_auth_models.py -v
+```
+
+Expected: 5 passed
+
+**Step 5: Generate Alembic migration**
+
+```bash
+cd apps/backend && uv run alembic revision --autogenerate -m "add auth tables"
+```
+
+Verify the generated migration creates `authorization_codes` and `refresh_tokens` tables with correct columns and FKs.
+
+**Step 6: Run migration**
+
+```bash
+cd apps/backend && uv run alembic upgrade head
+```
+
+**Step 7: Commit**
+
+```bash
+git add apps/backend/app/models.py apps/backend/alembic/versions/ apps/backend/tests/unit/test_auth_models.py
+git commit -m "feat(m2): add AuthorizationCode and RefreshToken models with migration"
+```
+
+---
+
+### Task 4: Password Module (TDD)
+
+**Files:**
+- Create: `apps/backend/app/auth/password.py`
+- Create: `apps/backend/tests/unit/test_password.py`
+
+**Step 1: Write failing tests**
+
+```python
+# apps/backend/tests/unit/test_password.py
+"""Tests for argon2id password hashing."""
+
+import pytest
+from app.auth.password import hash_password, verify_password
+
+
+class TestPasswordHashing:
+    def test_hash_returns_argon2id_string(self) -> None:
+        hashed = hash_password("mysecretpassword")
+        assert hashed.startswith("$argon2id$")
+
+    def test_hash_is_not_plaintext(self) -> None:
+        hashed = hash_password("mysecretpassword")
+        assert hashed != "mysecretpassword"
+
+    def test_verify_correct_password(self) -> None:
+        hashed = hash_password("mysecretpassword")
+        assert verify_password("mysecretpassword", hashed) is True
+
+    def test_verify_wrong_password(self) -> None:
+        hashed = hash_password("mysecretpassword")
+        assert verify_password("wrongpassword", hashed) is False
+
+    def test_different_passwords_produce_different_hashes(self) -> None:
+        h1 = hash_password("password1")
+        h2 = hash_password("password2")
+        assert h1 != h2
+
+    def test_same_password_produces_different_hashes(self) -> None:
+        h1 = hash_password("samepassword")
+        h2 = hash_password("samepassword")
+        assert h1 != h2  # salt should differ
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_password.py -v
+```
+
+Expected: FAIL -- `ModuleNotFoundError: No module named 'app.auth.password'`
+
+**Step 3: Implement password module**
+
+```python
+# apps/backend/app/auth/password.py
+"""Password hashing with argon2id."""
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+_hasher = PasswordHasher()
+
+
+def hash_password(password: str) -> str:
+    """Hash a password using argon2id."""
+    return _hasher.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Verify a password against an argon2id hash."""
+    try:
+        return _hasher.verify(hashed, password)
+    except VerifyMismatchError:
+        return False
+```
+
+**Step 4: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_password.py -v
+```
+
+Expected: 6 passed
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/auth/password.py apps/backend/tests/unit/test_password.py
+git commit -m "feat(m2): add argon2id password hashing module"
+```
+
+---
+
+### Task 5: JWT Module (TDD)
+
+**Files:**
+- Create: `apps/backend/app/auth/jwt.py`
+- Create: `apps/backend/tests/unit/test_jwt.py`
+
+**Step 1: Write failing tests**
+
+```python
+# apps/backend/tests/unit/test_jwt.py
+"""Tests for JWT access token creation and verification."""
+
+import time
+
+import pytest
+from app.auth.jwt import create_access_token, verify_access_token
+
+
+TEST_SECRET = "test-secret-key-for-unit-tests-only"
+
+
+class TestJWT:
+    def test_create_returns_string(self) -> None:
+        token = create_access_token(
+            user_id="user-123", email="test@example.com", secret=TEST_SECRET
+        )
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_verify_valid_token(self) -> None:
+        token = create_access_token(
+            user_id="user-123", email="test@example.com", secret=TEST_SECRET
+        )
+        claims = verify_access_token(token, secret=TEST_SECRET)
+        assert claims["sub"] == "user-123"
+        assert claims["email"] == "test@example.com"
+
+    def test_verify_expired_token(self) -> None:
+        token = create_access_token(
+            user_id="user-123",
+            email="test@example.com",
+            secret=TEST_SECRET,
+            expires_minutes=0,
+        )
+        # Token with 0 minutes is already expired
+        time.sleep(1)
+        with pytest.raises(ValueError, match="expired"):
+            verify_access_token(token, secret=TEST_SECRET)
+
+    def test_verify_invalid_signature(self) -> None:
+        token = create_access_token(
+            user_id="user-123", email="test@example.com", secret=TEST_SECRET
+        )
+        with pytest.raises(ValueError, match="invalid"):
+            verify_access_token(token, secret="wrong-secret")
+
+    def test_verify_malformed_token(self) -> None:
+        with pytest.raises(ValueError):
+            verify_access_token("not.a.jwt", secret=TEST_SECRET)
+
+    def test_token_contains_iss_claim(self) -> None:
+        token = create_access_token(
+            user_id="user-123", email="test@example.com", secret=TEST_SECRET
+        )
+        claims = verify_access_token(token, secret=TEST_SECRET)
+        assert claims["iss"] == "resume-matcher"
+
+    def test_token_contains_exp_and_iat(self) -> None:
+        token = create_access_token(
+            user_id="user-123", email="test@example.com", secret=TEST_SECRET
+        )
+        claims = verify_access_token(token, secret=TEST_SECRET)
+        assert "exp" in claims
+        assert "iat" in claims
+        assert claims["exp"] > claims["iat"]
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_jwt.py -v
+```
+
+Expected: FAIL -- `ModuleNotFoundError: No module named 'app.auth.jwt'`
+
+**Step 3: Implement JWT module**
+
+```python
+# apps/backend/app/auth/jwt.py
+"""JWT access token operations using joserfc."""
+
+import time
+
+from joserfc import jwt
+from joserfc.jwk import OctKey
+
+from app.auth.constants import ACCESS_TOKEN_EXPIRE_MINUTES
+
+_ALGORITHM = "HS256"
+_ISSUER = "resume-matcher"
+
+
+def create_access_token(
+    user_id: str,
+    email: str,
+    secret: str,
+    expires_minutes: int = ACCESS_TOKEN_EXPIRE_MINUTES,
+) -> str:
+    """Create a signed JWT access token."""
+    now = int(time.time())
+    claims = {
+        "sub": user_id,
+        "email": email,
+        "iss": _ISSUER,
+        "iat": now,
+        "exp": now + (expires_minutes * 60),
+    }
+    key = OctKey.import_key(secret)
+    token = jwt.encode({"alg": _ALGORITHM}, claims, key)
+    return token
+
+
+def verify_access_token(token: str, secret: str) -> dict:
+    """Verify and decode a JWT access token. Raises ValueError on failure."""
+    key = OctKey.import_key(secret)
+    try:
+        decoded = jwt.decode(token, key)
+    except Exception as e:
+        raise ValueError(f"Token invalid: {e}") from e
+
+    claims = decoded.claims
+    now = int(time.time())
+    if claims.get("exp", 0) < now:
+        raise ValueError("Token expired")
+    if claims.get("iss") != _ISSUER:
+        raise ValueError("Token invalid: wrong issuer")
+    return claims
+```
+
+**Step 4: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_jwt.py -v
+```
+
+Expected: 7 passed
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/auth/jwt.py apps/backend/tests/unit/test_jwt.py
+git commit -m "feat(m2): add JWT access token module with joserfc"
+```
+
+---
+
+### Task 6: PKCE Module (TDD)
+
+**Files:**
+- Create: `apps/backend/app/auth/pkce.py`
+- Create: `apps/backend/tests/unit/test_pkce.py`
+
+**Step 1: Write failing tests**
+
+```python
+# apps/backend/tests/unit/test_pkce.py
+"""Tests for PKCE S256 code challenge verification."""
+
+import base64
+import hashlib
+
+import pytest
+from app.auth.pkce import verify_code_challenge
+
+
+class TestPKCE:
+    def _make_challenge(self, verifier: str) -> str:
+        """Helper: compute S256 challenge from verifier."""
+        digest = hashlib.sha256(verifier.encode("ascii")).digest()
+        return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+    def test_valid_s256_challenge(self) -> None:
+        verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        challenge = self._make_challenge(verifier)
+        assert verify_code_challenge(verifier, challenge, "S256") is True
+
+    def test_wrong_verifier(self) -> None:
+        verifier = "correct-verifier"
+        challenge = self._make_challenge(verifier)
+        assert verify_code_challenge("wrong-verifier", challenge, "S256") is False
+
+    def test_plain_method_rejected(self) -> None:
+        with pytest.raises(ValueError, match="S256"):
+            verify_code_challenge("verifier", "challenge", "plain")
+
+    def test_empty_verifier_rejected(self) -> None:
+        assert verify_code_challenge("", "somechallenge", "S256") is False
+
+    def test_rfc7636_test_vector(self) -> None:
+        # RFC 7636 Appendix B test vector
+        verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        expected_challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        assert verify_code_challenge(verifier, expected_challenge, "S256") is True
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_pkce.py -v
+```
+
+Expected: FAIL -- `ModuleNotFoundError`
+
+**Step 3: Implement PKCE module**
+
+```python
+# apps/backend/app/auth/pkce.py
+"""PKCE (RFC 7636) code challenge verification."""
+
+import base64
+import hashlib
+
+
+def verify_code_challenge(
+    code_verifier: str, code_challenge: str, method: str
+) -> bool:
+    """Verify a PKCE code challenge against a code verifier.
+
+    Only S256 is supported (OAuth 2.1 mandate).
+    """
+    if method != "S256":
+        raise ValueError("Only S256 code_challenge_method is supported")
+    if not code_verifier:
+        return False
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    computed = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return computed == code_challenge
+```
+
+**Step 4: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_pkce.py -v
+```
+
+Expected: 5 passed
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/auth/pkce.py apps/backend/tests/unit/test_pkce.py
+git commit -m "feat(m2): add PKCE S256 verification module"
+```
+
+---
+
+### Task 7: Database User Operations (TDD)
+
+**Files:**
+- Modify: `apps/backend/app/database.py`
+- Create: `apps/backend/tests/unit/test_auth_database.py`
+
+**Step 1: Write failing tests for user CRUD**
+
+```python
+# apps/backend/tests/unit/test_auth_database.py
+"""Tests for auth-related database operations."""
+
+import pytest
+from app.database import Database
+
+
+@pytest.fixture
+async def db():
+    database = Database("sqlite+aiosqlite://")
+    await database.init()
+    yield database
+    await database.close()
+
+
+class TestUserOperations:
+    async def test_create_user(self, db: Database) -> None:
+        user = await db.create_user(
+            email="test@example.com",
+            hashed_password="$argon2id$fakehash",
+            display_name="Test User",
+        )
+        assert user["email"] == "test@example.com"
+        assert user["display_name"] == "Test User"
+        assert "id" in user
+        assert "hashed_password" not in user  # never expose password hash
+
+    async def test_get_user_by_email(self, db: Database) -> None:
+        await db.create_user(email="find@example.com", hashed_password="hash")
+        user = await db.get_user_by_email("find@example.com")
+        assert user is not None
+        assert user["email"] == "find@example.com"
+
+    async def test_get_user_by_email_not_found(self, db: Database) -> None:
+        user = await db.get_user_by_email("nobody@example.com")
+        assert user is None
+
+    async def test_get_user_by_email_includes_password_hash(self, db: Database) -> None:
+        await db.create_user(email="auth@example.com", hashed_password="$argon2id$hash")
+        user = await db.get_user_by_email("auth@example.com")
+        assert user["hashed_password"] == "$argon2id$hash"
+
+    async def test_get_user_by_id(self, db: Database) -> None:
+        created = await db.create_user(email="id@example.com", hashed_password="hash")
+        user = await db.get_user_by_id(created["id"])
+        assert user is not None
+        assert user["email"] == "id@example.com"
+        assert "hashed_password" not in user
+
+    async def test_get_user_by_id_not_found(self, db: Database) -> None:
+        user = await db.get_user_by_id("nonexistent-id")
+        assert user is None
+
+    async def test_duplicate_email_raises(self, db: Database) -> None:
+        await db.create_user(email="dup@example.com", hashed_password="hash")
+        with pytest.raises(Exception):
+            await db.create_user(email="dup@example.com", hashed_password="hash2")
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_auth_database.py::TestUserOperations -v
+```
+
+Expected: FAIL -- `AttributeError: 'Database' object has no attribute 'create_user'`
+
+**Step 3: Implement user operations in database.py**
+
+Add to `Database` class in `apps/backend/app/database.py`:
+
+1. Add `User` to the import from `app.models`:
+   ```python
+   from app.models import Base, Improvement, Job, Resume, User
+   ```
+
+2. Add static method for User dict conversion:
+   ```python
+    @staticmethod
+    def _user_to_dict(u: User, include_password: bool = False) -> dict[str, Any]:
+        d = {
+            "id": u.id,
+            "email": u.email,
+            "display_name": u.display_name,
+            "is_active": u.is_active,
+            "created_at": u.created_at.isoformat() if u.created_at else None,
+            "updated_at": u.updated_at.isoformat() if u.updated_at else None,
+        }
+        if include_password:
+            d["hashed_password"] = u.hashed_password
+        return d
+   ```
+
+3. Add user CRUD methods:
+   ```python
+    # -- User operations -------------------------------------------------------
+
+    async def create_user(
+        self,
+        email: str,
+        hashed_password: str,
+        display_name: str | None = None,
+    ) -> dict[str, Any]:
+        user = User(
+            id=str(uuid4()),
+            email=email,
+            hashed_password=hashed_password,
+            display_name=display_name,
+        )
+        async with self._session() as session:
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+            return self._user_to_dict(user)
+
+    async def get_user_by_email(self, email: str) -> dict[str, Any] | None:
+        async with self._session() as session:
+            result = await session.execute(select(User).where(User.email == email))
+            row = result.scalar_one_or_none()
+            return self._user_to_dict(row, include_password=True) if row else None
+
+    async def get_user_by_id(self, user_id: str) -> dict[str, Any] | None:
+        async with self._session() as session:
+            result = await session.execute(select(User).where(User.id == user_id))
+            row = result.scalar_one_or_none()
+            return self._user_to_dict(row) if row else None
+   ```
+
+**Step 4: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_auth_database.py::TestUserOperations -v
+```
+
+Expected: 7 passed
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/database.py apps/backend/tests/unit/test_auth_database.py
+git commit -m "feat(m2): add user CRUD operations to database layer"
+```
+
+---
+
+### Task 8: Database Auth Code + Refresh Token Operations (TDD)
+
+**Files:**
+- Modify: `apps/backend/app/database.py`
+- Modify: `apps/backend/tests/unit/test_auth_database.py`
+
+**Step 1: Write failing tests for auth code operations**
+
+Append to `test_auth_database.py`:
+
+```python
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+class TestAuthorizationCodeOperations:
+    async def test_create_and_get_auth_code(self, db: Database) -> None:
+        user = await db.create_user(email="code@example.com", hashed_password="hash")
+        code_hash = _hash("authcode123")
+        await db.create_authorization_code(
+            code_hash=code_hash,
+            user_id=user["id"],
+            client_id="resume-matcher-web",
+            redirect_uri="http://localhost:3000/callback",
+            code_challenge="E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+        )
+        code = await db.get_authorization_code(code_hash)
+        assert code is not None
+        assert code["user_id"] == user["id"]
+        assert code["client_id"] == "resume-matcher-web"
+        assert code["used_at"] is None
+
+    async def test_mark_code_used(self, db: Database) -> None:
+        user = await db.create_user(email="used@example.com", hashed_password="hash")
+        code_hash = _hash("usedcode")
+        await db.create_authorization_code(
+            code_hash=code_hash,
+            user_id=user["id"],
+            client_id="resume-matcher-web",
+            redirect_uri="http://localhost:3000/callback",
+            code_challenge="challenge",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+        )
+        await db.mark_authorization_code_used(code_hash)
+        code = await db.get_authorization_code(code_hash)
+        assert code["used_at"] is not None
+
+    async def test_get_nonexistent_code(self, db: Database) -> None:
+        code = await db.get_authorization_code(_hash("nonexistent"))
+        assert code is None
+
+
+class TestRefreshTokenOperations:
+    async def test_create_and_get_refresh_token(self, db: Database) -> None:
+        user = await db.create_user(email="refresh@example.com", hashed_password="hash")
+        token_hash = _hash("refreshtoken123")
+        token = await db.create_refresh_token(
+            token_hash=token_hash,
+            user_id=user["id"],
+            family_id="family-001",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        assert token["user_id"] == user["id"]
+        assert token["family_id"] == "family-001"
+        assert token["revoked_at"] is None
+
+        fetched = await db.get_refresh_token(token_hash)
+        assert fetched is not None
+        assert fetched["family_id"] == "family-001"
+
+    async def test_revoke_refresh_token(self, db: Database) -> None:
+        user = await db.create_user(email="revoke@example.com", hashed_password="hash")
+        token_hash = _hash("torevoke")
+        await db.create_refresh_token(
+            token_hash=token_hash,
+            user_id=user["id"],
+            family_id="family-002",
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        await db.revoke_refresh_token(token_hash)
+        token = await db.get_refresh_token(token_hash)
+        assert token["revoked_at"] is not None
+
+    async def test_revoke_token_family(self, db: Database) -> None:
+        user = await db.create_user(email="family@example.com", hashed_password="hash")
+        family_id = "family-003"
+        for i in range(3):
+            await db.create_refresh_token(
+                token_hash=_hash(f"familytoken{i}"),
+                user_id=user["id"],
+                family_id=family_id,
+                expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+            )
+        await db.revoke_token_family(family_id)
+        for i in range(3):
+            token = await db.get_refresh_token(_hash(f"familytoken{i}"))
+            assert token["revoked_at"] is not None
+
+    async def test_get_nonexistent_refresh_token(self, db: Database) -> None:
+        token = await db.get_refresh_token(_hash("nonexistent"))
+        assert token is None
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_auth_database.py -v -k "AuthorizationCode or RefreshToken"
+```
+
+Expected: FAIL -- `AttributeError: 'Database' object has no attribute 'create_authorization_code'`
+
+**Step 3: Implement auth operations in database.py**
+
+Add imports at top of `database.py`:
+
+```python
+from app.models import Base, AuthorizationCode, Improvement, Job, RefreshToken, Resume, User
+```
+
+Add static conversion methods and CRUD operations to `Database`:
+
+```python
+    @staticmethod
+    def _auth_code_to_dict(c: AuthorizationCode) -> dict[str, Any]:
+        return {
+            "code_hash": c.code_hash,
+            "user_id": c.user_id,
+            "client_id": c.client_id,
+            "redirect_uri": c.redirect_uri,
+            "code_challenge": c.code_challenge,
+            "scope": c.scope,
+            "expires_at": c.expires_at.isoformat() if c.expires_at else None,
+            "used_at": c.used_at.isoformat() if c.used_at else None,
+            "created_at": c.created_at.isoformat() if c.created_at else None,
+        }
+
+    @staticmethod
+    def _refresh_token_to_dict(t: RefreshToken) -> dict[str, Any]:
+        return {
+            "id": t.id,
+            "token_hash": t.token_hash,
+            "user_id": t.user_id,
+            "family_id": t.family_id,
+            "expires_at": t.expires_at.isoformat() if t.expires_at else None,
+            "revoked_at": t.revoked_at.isoformat() if t.revoked_at else None,
+            "created_at": t.created_at.isoformat() if t.created_at else None,
+        }
+
+    # -- Authorization code operations ----------------------------------------
+
+    async def create_authorization_code(
+        self,
+        code_hash: str,
+        user_id: str,
+        client_id: str,
+        redirect_uri: str,
+        code_challenge: str,
+        expires_at: datetime,
+        scope: str | None = None,
+    ) -> dict[str, Any]:
+        code = AuthorizationCode(
+            code_hash=code_hash,
+            user_id=user_id,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_challenge=code_challenge,
+            scope=scope,
+            expires_at=expires_at,
+        )
+        async with self._session() as session:
+            session.add(code)
+            await session.commit()
+            await session.refresh(code)
+            return self._auth_code_to_dict(code)
+
+    async def get_authorization_code(self, code_hash: str) -> dict[str, Any] | None:
+        async with self._session() as session:
+            result = await session.execute(
+                select(AuthorizationCode).where(AuthorizationCode.code_hash == code_hash)
+            )
+            row = result.scalar_one_or_none()
+            return self._auth_code_to_dict(row) if row else None
+
+    async def mark_authorization_code_used(self, code_hash: str) -> None:
+        async with self._session() as session:
+            await session.execute(
+                update(AuthorizationCode)
+                .where(AuthorizationCode.code_hash == code_hash)
+                .values(used_at=datetime.now(timezone.utc))
+            )
+            await session.commit()
+
+    # -- Refresh token operations ---------------------------------------------
+
+    async def create_refresh_token(
+        self,
+        token_hash: str,
+        user_id: str,
+        family_id: str,
+        expires_at: datetime,
+    ) -> dict[str, Any]:
+        token = RefreshToken(
+            id=str(uuid4()),
+            token_hash=token_hash,
+            user_id=user_id,
+            family_id=family_id,
+            expires_at=expires_at,
+        )
+        async with self._session() as session:
+            session.add(token)
+            await session.commit()
+            await session.refresh(token)
+            return self._refresh_token_to_dict(token)
+
+    async def get_refresh_token(self, token_hash: str) -> dict[str, Any] | None:
+        async with self._session() as session:
+            result = await session.execute(
+                select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+            )
+            row = result.scalar_one_or_none()
+            return self._refresh_token_to_dict(row) if row else None
+
+    async def revoke_refresh_token(self, token_hash: str) -> None:
+        async with self._session() as session:
+            await session.execute(
+                update(RefreshToken)
+                .where(RefreshToken.token_hash == token_hash)
+                .values(revoked_at=datetime.now(timezone.utc))
+            )
+            await session.commit()
+
+    async def revoke_token_family(self, family_id: str) -> None:
+        async with self._session() as session:
+            await session.execute(
+                update(RefreshToken)
+                .where(RefreshToken.family_id == family_id)
+                .where(RefreshToken.revoked_at.is_(None))
+                .values(revoked_at=datetime.now(timezone.utc))
+            )
+            await session.commit()
+```
+
+**Step 4: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_auth_database.py -v
+```
+
+Expected: all passed (7 user + 7 auth code/refresh token = 14 total)
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/database.py apps/backend/tests/unit/test_auth_database.py
+git commit -m "feat(m2): add auth code and refresh token database operations"
+```
+
+---
+
+### Task 9: Auth Schemas
+
+**Files:**
+- Create: `apps/backend/app/schemas/auth.py`
+
+**Step 1: Create Pydantic schemas**
+
+```python
+# apps/backend/app/schemas/auth.py
+"""Pydantic schemas for authentication endpoints."""
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+    display_name: str | None = Field(default=None, max_length=255)
+
+
+class RegisterResponse(BaseModel):
+    id: str
+    email: str
+    display_name: str | None
+
+
+class AuthorizeRequest(BaseModel):
+    """OAuth 2.1 authorization request with embedded credentials."""
+    email: EmailStr
+    password: str
+    client_id: str
+    redirect_uri: str
+    code_challenge: str
+    code_challenge_method: str = "S256"
+    state: str | None = None
+    scope: str | None = None
+
+
+class TokenRequest(BaseModel):
+    """OAuth 2.1 token exchange request."""
+    grant_type: str  # "authorization_code" or "refresh_token"
+    code: str | None = None
+    code_verifier: str | None = None
+    client_id: str | None = None
+    redirect_uri: str | None = None
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "Bearer"
+    expires_in: int
+
+
+class UserResponse(BaseModel):
+    id: str
+    email: str
+    display_name: str | None
+    is_active: bool
+    created_at: str | None
+
+
+class ErrorResponse(BaseModel):
+    """RFC 6750 error response."""
+    error: str
+    error_description: str | None = None
+```
+
+Note: `EmailStr` requires `pydantic[email]`. Add `"email-validator>=2.0"` to `pyproject.toml` dependencies if not already present.
+
+**Step 2: Commit**
+
+```bash
+git add apps/backend/app/schemas/auth.py apps/backend/pyproject.toml
+git commit -m "feat(m2): add auth Pydantic schemas"
+```
+
+---
+
+### Task 10: Registration Endpoint (TDD)
+
+**Files:**
+- Create: `apps/backend/app/routers/auth.py`
+- Create: `apps/backend/tests/integration/test_register_api.py`
+
+**Step 1: Write failing tests**
+
+```python
+# apps/backend/tests/integration/test_register_api.py
+"""Integration tests for user registration."""
+
+import pytest
+
+
+class TestRegister:
+    async def test_register_success(self, client) -> None:
+        resp = await client.post("/api/v1/auth/register", json={
+            "email": "new@example.com",
+            "password": "securepassword123",
+            "display_name": "New User",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["email"] == "new@example.com"
+        assert data["display_name"] == "New User"
+        assert "id" in data
+        assert "password" not in data
+
+    async def test_register_duplicate_email(self, client) -> None:
+        await client.post("/api/v1/auth/register", json={
+            "email": "dup@example.com",
+            "password": "password123456",
+        })
+        resp = await client.post("/api/v1/auth/register", json={
+            "email": "dup@example.com",
+            "password": "password123456",
+        })
+        assert resp.status_code == 409
+
+    async def test_register_invalid_email(self, client) -> None:
+        resp = await client.post("/api/v1/auth/register", json={
+            "email": "not-an-email",
+            "password": "password123456",
+        })
+        assert resp.status_code == 422
+
+    async def test_register_short_password(self, client) -> None:
+        resp = await client.post("/api/v1/auth/register", json={
+            "email": "short@example.com",
+            "password": "short",
+        })
+        assert resp.status_code == 422
+
+    async def test_register_no_display_name(self, client) -> None:
+        resp = await client.post("/api/v1/auth/register", json={
+            "email": "noname@example.com",
+            "password": "password123456",
+        })
+        assert resp.status_code == 201
+        assert resp.json()["display_name"] is None
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_register_api.py -v
+```
+
+Expected: FAIL -- 404 (route not registered yet)
+
+**Step 3: Implement auth router**
+
+```python
+# apps/backend/app/routers/auth.py
+"""Auth endpoints: registration and user profile."""
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+
+from app.auth.password import hash_password
+from app.database import db
+from app.schemas.auth import RegisterRequest, RegisterResponse, UserResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=RegisterResponse, status_code=201)
+async def register(body: RegisterRequest) -> RegisterResponse:
+    """Register a new user account."""
+    existing = await db.get_user_by_email(body.email)
+    if existing:
+        raise HTTPException(status_code=409, detail="Email already registered")
+
+    hashed = hash_password(body.password)
+    user = await db.create_user(
+        email=body.email,
+        hashed_password=hashed,
+        display_name=body.display_name,
+    )
+    return RegisterResponse(
+        id=user["id"],
+        email=user["email"],
+        display_name=user["display_name"],
+    )
+```
+
+**Step 4: Register the router in main.py and routers/__init__.py**
+
+In `apps/backend/app/routers/__init__.py`, add:
+```python
+from app.routers.auth import router as auth_router
+```
+and add `"auth_router"` to `__all__`.
+
+In `apps/backend/app/main.py`, import and include:
+```python
+from app.routers import auth_router
+# ...
+app.include_router(auth_router, prefix="/api/v1")
+```
+
+**Step 5: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_register_api.py -v
+```
+
+Expected: 5 passed
+
+**Step 6: Commit**
+
+```bash
+git add apps/backend/app/routers/auth.py apps/backend/app/routers/__init__.py apps/backend/app/main.py apps/backend/tests/integration/test_register_api.py
+git commit -m "feat(m2): add user registration endpoint"
+```
+
+---
+
+### Task 11: OAuth Authorize Endpoint (TDD)
+
+**Files:**
+- Create: `apps/backend/app/routers/oauth.py`
+- Create: `apps/backend/tests/integration/test_oauth_flow_api.py`
+
+**Step 1: Write failing tests**
+
+```python
+# apps/backend/tests/integration/test_oauth_flow_api.py
+"""Integration tests for OAuth 2.1 authorization flow."""
+
+import base64
+import hashlib
+import secrets
+
+import pytest
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE code_verifier and code_challenge."""
+    verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+async def _register_user(client, email: str = "oauth@example.com", password: str = "password123456"):
+    await client.post("/api/v1/auth/register", json={
+        "email": email,
+        "password": password,
+    })
+
+
+class TestAuthorize:
+    async def test_authorize_success_returns_redirect(self, client) -> None:
+        await _register_user(client)
+        verifier, challenge = _pkce_pair()
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "oauth@example.com",
+            "password": "password123456",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "random-state",
+        }, follow_redirects=False)
+        assert resp.status_code == 303
+        location = resp.headers["location"]
+        assert "code=" in location
+        assert "state=random-state" in location
+        assert location.startswith("http://localhost:3000/callback")
+
+    async def test_authorize_wrong_password(self, client) -> None:
+        await _register_user(client)
+        _, challenge = _pkce_pair()
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "oauth@example.com",
+            "password": "wrongpassword",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }, follow_redirects=False)
+        assert resp.status_code == 401
+
+    async def test_authorize_unknown_client(self, client) -> None:
+        await _register_user(client)
+        _, challenge = _pkce_pair()
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "oauth@example.com",
+            "password": "password123456",
+            "client_id": "unknown-client",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }, follow_redirects=False)
+        assert resp.status_code == 400
+
+    async def test_authorize_invalid_redirect_uri(self, client) -> None:
+        await _register_user(client)
+        _, challenge = _pkce_pair()
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "oauth@example.com",
+            "password": "password123456",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://evil.com/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }, follow_redirects=False)
+        assert resp.status_code == 400
+
+    async def test_authorize_missing_code_challenge(self, client) -> None:
+        await _register_user(client)
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "oauth@example.com",
+            "password": "password123456",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge_method": "S256",
+        }, follow_redirects=False)
+        assert resp.status_code == 422
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_oauth_flow_api.py::TestAuthorize -v
+```
+
+Expected: FAIL -- 404
+
+**Step 3: Implement OAuth router (authorize endpoint)**
+
+```python
+# apps/backend/app/routers/oauth.py
+"""OAuth 2.1 endpoints: authorize, token, revoke, discovery."""
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, HTTPException, Response
+from fastapi.responses import RedirectResponse
+
+from app.auth.constants import (
+    AUTHORIZATION_CODE_EXPIRE_MINUTES,
+    FIRST_PARTY_CLIENT_ID,
+    FIRST_PARTY_REDIRECT_URIS,
+)
+from app.auth.password import verify_password
+from app.config import settings
+from app.database import db
+from app.schemas.auth import AuthorizeRequest
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/oauth", tags=["oauth"])
+
+
+def _allowed_redirect_uris() -> list[str]:
+    """Build list of allowed redirect URIs including dynamic frontend origin."""
+    uris = list(FIRST_PARTY_REDIRECT_URIS)
+    dynamic = f"{settings.frontend_origin.rstrip('/')}/callback"
+    if dynamic not in uris:
+        uris.append(dynamic)
+    return uris
+
+
+def _validate_client(client_id: str, redirect_uri: str) -> None:
+    """Validate client_id and redirect_uri against known clients."""
+    if client_id != FIRST_PARTY_CLIENT_ID:
+        raise HTTPException(status_code=400, detail="Unknown client_id")
+    if redirect_uri not in _allowed_redirect_uris():
+        raise HTTPException(status_code=400, detail="Invalid redirect_uri")
+
+
+@router.post("/authorize")
+async def authorize(body: AuthorizeRequest) -> Response:
+    """OAuth 2.1 authorization endpoint with embedded credentials.
+
+    Validates credentials + PKCE, issues authorization code, redirects.
+    """
+    _validate_client(body.client_id, body.redirect_uri)
+
+    if body.code_challenge_method != "S256":
+        raise HTTPException(status_code=400, detail="Only S256 is supported")
+
+    # Authenticate user
+    user = await db.get_user_by_email(body.email)
+    if not user or not verify_password(body.password, user["hashed_password"]):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    if not user.get("is_active", True):
+        raise HTTPException(status_code=403, detail="Account disabled")
+
+    # Generate authorization code
+    code = secrets.token_urlsafe(32)
+    code_hash = hashlib.sha256(code.encode()).hexdigest()
+
+    await db.create_authorization_code(
+        code_hash=code_hash,
+        user_id=user["id"],
+        client_id=body.client_id,
+        redirect_uri=body.redirect_uri,
+        code_challenge=body.code_challenge,
+        scope=body.scope,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=AUTHORIZATION_CODE_EXPIRE_MINUTES),
+    )
+
+    # Redirect with code
+    params = {"code": code}
+    if body.state:
+        params["state"] = body.state
+    redirect_url = f"{body.redirect_uri}?{urlencode(params)}"
+    return RedirectResponse(url=redirect_url, status_code=303)
+```
+
+**Step 4: Register the OAuth router**
+
+In `apps/backend/app/routers/__init__.py`, add:
+```python
+from app.routers.oauth import router as oauth_router
+```
+and add `"oauth_router"` to `__all__`.
+
+In `apps/backend/app/main.py`:
+```python
+from app.routers import auth_router, oauth_router
+# ...
+app.include_router(oauth_router, prefix="/api/v1")
+```
+
+**Step 5: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_oauth_flow_api.py::TestAuthorize -v
+```
+
+Expected: 5 passed
+
+**Step 6: Commit**
+
+```bash
+git add apps/backend/app/routers/oauth.py apps/backend/app/routers/__init__.py apps/backend/app/main.py apps/backend/tests/integration/test_oauth_flow_api.py
+git commit -m "feat(m2): add OAuth 2.1 authorize endpoint with PKCE"
+```
+
+---
+
+### Task 12: OAuth Token Endpoint (TDD)
+
+**Files:**
+- Modify: `apps/backend/app/routers/oauth.py`
+- Modify: `apps/backend/tests/integration/test_oauth_flow_api.py`
+
+**Step 1: Write failing tests for token exchange**
+
+Append to `test_oauth_flow_api.py`:
+
+```python
+class TestTokenExchange:
+    async def _get_auth_code(self, client) -> tuple[str, str]:
+        """Helper: register, authorize, return (code, verifier)."""
+        await _register_user(client, "token@example.com")
+        verifier, challenge = _pkce_pair()
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "token@example.com",
+            "password": "password123456",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "state": "test",
+        }, follow_redirects=False)
+        location = resp.headers["location"]
+        # Extract code from redirect URL
+        from urllib.parse import parse_qs, urlparse
+        query = parse_qs(urlparse(location).query)
+        return query["code"][0], verifier
+
+    async def test_exchange_code_for_tokens(self, client) -> None:
+        code, verifier = await self._get_auth_code(client)
+        resp = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert data["token_type"] == "Bearer"
+        assert data["expires_in"] == 900  # 15 minutes
+        # Refresh token should be in httpOnly cookie
+        cookies = resp.cookies
+        # Note: httpx may not expose httpOnly cookies directly,
+        # check Set-Cookie header instead
+        set_cookie = resp.headers.get("set-cookie", "")
+        assert "refresh_token=" in set_cookie
+        assert "httponly" in set_cookie.lower()
+
+    async def test_exchange_wrong_verifier(self, client) -> None:
+        code, _ = await self._get_auth_code(client)
+        resp = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": "wrong-verifier",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+        })
+        assert resp.status_code == 400
+
+    async def test_exchange_code_replay(self, client) -> None:
+        code, verifier = await self._get_auth_code(client)
+        # First exchange succeeds
+        resp1 = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+        })
+        assert resp1.status_code == 200
+        # Second exchange fails (code already used)
+        resp2 = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+        })
+        assert resp2.status_code == 400
+
+    async def test_exchange_invalid_grant_type(self, client) -> None:
+        resp = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "password",
+            "code": "whatever",
+        })
+        assert resp.status_code == 400
+
+
+class TestRefreshToken:
+    async def _login_and_get_refresh_cookie(self, client) -> str:
+        """Helper: full login flow, return the Set-Cookie header value."""
+        await _register_user(client, "refresh@example.com")
+        verifier, challenge = _pkce_pair()
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "refresh@example.com",
+            "password": "password123456",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }, follow_redirects=False)
+        from urllib.parse import parse_qs, urlparse
+        query = parse_qs(urlparse(resp.headers["location"]).query)
+        code = query["code"][0]
+
+        token_resp = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+        })
+        return token_resp.headers.get("set-cookie", "")
+
+    async def test_refresh_token_rotation(self, client) -> None:
+        cookie_header = await self._login_and_get_refresh_cookie(client)
+        # Extract refresh token value from Set-Cookie
+        # Format: refresh_token=<value>; HttpOnly; ...
+        token_value = cookie_header.split("refresh_token=")[1].split(";")[0]
+
+        # Use refresh token
+        client.cookies.set("refresh_token", token_value)
+        resp = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "refresh_token",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        # New refresh cookie should be set (rotation)
+        new_cookie = resp.headers.get("set-cookie", "")
+        assert "refresh_token=" in new_cookie
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_oauth_flow_api.py -v -k "TokenExchange or RefreshToken"
+```
+
+Expected: FAIL -- 404 or 405 (token endpoint not implemented)
+
+**Step 3: Implement token endpoint in oauth.py**
+
+Add to `apps/backend/app/routers/oauth.py`:
+
+```python
+from app.auth.constants import ACCESS_TOKEN_EXPIRE_MINUTES, REFRESH_TOKEN_EXPIRE_DAYS
+from app.auth.jwt import create_access_token
+from app.auth.pkce import verify_code_challenge
+from app.schemas.auth import TokenRequest, TokenResponse
+
+
+@router.post("/token", response_model=TokenResponse)
+async def token(body: TokenRequest, response: Response) -> TokenResponse:
+    """OAuth 2.1 token endpoint: code exchange and refresh."""
+    if body.grant_type == "authorization_code":
+        return await _handle_code_exchange(body, response)
+    elif body.grant_type == "refresh_token":
+        return await _handle_refresh(body, response)
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported grant_type")
+
+
+async def _handle_code_exchange(body: TokenRequest, response: Response) -> TokenResponse:
+    """Exchange authorization code + PKCE verifier for tokens."""
+    if not body.code or not body.code_verifier or not body.client_id or not body.redirect_uri:
+        raise HTTPException(status_code=400, detail="Missing required parameters")
+
+    code_hash = hashlib.sha256(body.code.encode()).hexdigest()
+    stored = await db.get_authorization_code(code_hash)
+
+    if not stored:
+        raise HTTPException(status_code=400, detail="Invalid authorization code")
+
+    # Check expiry
+    expires_at = datetime.fromisoformat(stored["expires_at"])
+    if expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=400, detail="Authorization code expired")
+
+    # Check already used (replay attack)
+    if stored["used_at"] is not None:
+        raise HTTPException(status_code=400, detail="Authorization code already used")
+
+    # Validate client_id and redirect_uri match
+    if stored["client_id"] != body.client_id or stored["redirect_uri"] != body.redirect_uri:
+        raise HTTPException(status_code=400, detail="Client/redirect mismatch")
+
+    # Verify PKCE
+    if not verify_code_challenge(body.code_verifier, stored["code_challenge"], "S256"):
+        raise HTTPException(status_code=400, detail="PKCE verification failed")
+
+    # Mark code as used
+    await db.mark_authorization_code_used(code_hash)
+
+    # Get user
+    user = await db.get_user_by_id(stored["user_id"])
+    if not user:
+        raise HTTPException(status_code=400, detail="User not found")
+
+    # Issue tokens
+    return await _issue_tokens(user, response)
+
+
+async def _handle_refresh(body: TokenRequest, response: Response) -> TokenResponse:
+    """Refresh access token using refresh token from cookie."""
+    from fastapi import Request
+    # The refresh token comes from the cookie, injected below
+    raise HTTPException(status_code=400, detail="Missing refresh token")
+```
+
+Note: The refresh token handling needs access to the request cookie. Refactor the endpoint signature:
+
+```python
+from fastapi import Cookie, Request
+
+@router.post("/token", response_model=TokenResponse)
+async def token(
+    body: TokenRequest,
+    response: Response,
+    request: Request,
+) -> TokenResponse:
+    """OAuth 2.1 token endpoint: code exchange and refresh."""
+    if body.grant_type == "authorization_code":
+        return await _handle_code_exchange(body, response)
+    elif body.grant_type == "refresh_token":
+        refresh_cookie = request.cookies.get("refresh_token")
+        if not refresh_cookie:
+            raise HTTPException(status_code=400, detail="Missing refresh token")
+        return await _handle_refresh(refresh_cookie, response)
+    else:
+        raise HTTPException(status_code=400, detail="Unsupported grant_type")
+
+
+async def _handle_refresh(refresh_token_value: str, response: Response) -> TokenResponse:
+    """Refresh: validate token, rotate, issue new tokens."""
+    token_hash = hashlib.sha256(refresh_token_value.encode()).hexdigest()
+    stored = await db.get_refresh_token(token_hash)
+
+    if not stored:
+        raise HTTPException(status_code=400, detail="Invalid refresh token")
+
+    # Check revoked (reuse detection)
+    if stored["revoked_at"] is not None:
+        # Potential token theft -- revoke entire family
+        await db.revoke_token_family(stored["family_id"])
+        logger.warning("Refresh token reuse detected for family %s", stored["family_id"])
+        raise HTTPException(status_code=400, detail="Token reuse detected")
+
+    # Check expiry
+    expires_at = datetime.fromisoformat(stored["expires_at"])
+    if expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=400, detail="Refresh token expired")
+
+    # Revoke old token
+    await db.revoke_refresh_token(token_hash)
+
+    # Get user
+    user = await db.get_user_by_id(stored["user_id"])
+    if not user:
+        raise HTTPException(status_code=400, detail="User not found")
+
+    # Issue new tokens with same family_id
+    return await _issue_tokens(user, response, family_id=stored["family_id"])
+
+
+async def _issue_tokens(
+    user: dict, response: Response, family_id: str | None = None,
+) -> TokenResponse:
+    """Create access token (JWT) and refresh token (cookie)."""
+    access_token = create_access_token(
+        user_id=user["id"],
+        email=user["email"],
+        secret=settings.effective_jwt_secret,
+    )
+
+    # Create refresh token
+    raw_refresh = secrets.token_urlsafe(32)
+    refresh_hash = hashlib.sha256(raw_refresh.encode()).hexdigest()
+    fid = family_id or str(secrets.token_urlsafe(16))
+
+    await db.create_refresh_token(
+        token_hash=refresh_hash,
+        user_id=user["id"],
+        family_id=fid,
+        expires_at=datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
+    )
+
+    # Set refresh token as httpOnly cookie
+    response.set_cookie(
+        key="refresh_token",
+        value=raw_refresh,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        max_age=REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        path="/api/v1/oauth/token",  # only sent to token endpoint
+    )
+    # Set a non-httpOnly flag cookie for the frontend to detect sessions
+    response.set_cookie(
+        key="has_session",
+        value="1",
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        max_age=REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        path="/",
+    )
+
+    return TokenResponse(
+        access_token=access_token,
+        token_type="Bearer",
+        expires_in=ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    )
+```
+
+**Step 4: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_oauth_flow_api.py -v
+```
+
+Expected: all passed
+
+Note: Tests may need `JWT_SECRET_KEY` set. Update `conftest.py` to set it:
+
+```python
+@pytest.fixture(autouse=True)
+def set_jwt_secret(monkeypatch):
+    monkeypatch.setattr("app.config.settings.jwt_secret_key", "test-secret-for-tests")
+```
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/routers/oauth.py apps/backend/tests/
+git commit -m "feat(m2): add OAuth 2.1 token endpoint with PKCE exchange and refresh rotation"
+```
+
+---
+
+### Task 13: Auth Dependencies + /me Endpoint (TDD)
+
+**Files:**
+- Create: `apps/backend/app/auth/dependencies.py`
+- Modify: `apps/backend/app/routers/auth.py`
+- Create: `apps/backend/tests/integration/test_auth_me_api.py`
+
+**Step 1: Write failing tests**
+
+```python
+# apps/backend/tests/integration/test_auth_me_api.py
+"""Integration tests for /auth/me and auth dependencies."""
+
+import base64
+import hashlib
+import secrets
+
+import pytest
+from urllib.parse import parse_qs, urlparse
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+async def _full_login(client, email="me@example.com", password="password123456") -> str:
+    """Register + OAuth flow, return access_token."""
+    await client.post("/api/v1/auth/register", json={
+        "email": email, "password": password,
+    })
+    verifier, challenge = _pkce_pair()
+    resp = await client.post("/api/v1/oauth/authorize", json={
+        "email": email,
+        "password": password,
+        "client_id": "resume-matcher-web",
+        "redirect_uri": "http://localhost:3000/callback",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }, follow_redirects=False)
+    query = parse_qs(urlparse(resp.headers["location"]).query)
+    code = query["code"][0]
+    token_resp = await client.post("/api/v1/oauth/token", json={
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": verifier,
+        "client_id": "resume-matcher-web",
+        "redirect_uri": "http://localhost:3000/callback",
+    })
+    return token_resp.json()["access_token"]
+
+
+class TestAuthMe:
+    async def test_me_authenticated(self, client) -> None:
+        token = await _full_login(client)
+        resp = await client.get("/api/v1/auth/me", headers={
+            "Authorization": f"Bearer {token}",
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email"] == "me@example.com"
+        assert "hashed_password" not in data
+
+    async def test_me_no_token(self, client) -> None:
+        resp = await client.get("/api/v1/auth/me")
+        assert resp.status_code == 401
+        assert "WWW-Authenticate" in resp.headers
+
+    async def test_me_invalid_token(self, client) -> None:
+        resp = await client.get("/api/v1/auth/me", headers={
+            "Authorization": "Bearer invalid-token",
+        })
+        assert resp.status_code == 401
+
+    async def test_me_expired_token(self, client) -> None:
+        # Create a token with 0 expiry
+        from app.auth.jwt import create_access_token
+        import time
+        token = create_access_token(
+            user_id="fake", email="fake@example.com",
+            secret="test-secret-for-tests", expires_minutes=0,
+        )
+        time.sleep(1)
+        resp = await client.get("/api/v1/auth/me", headers={
+            "Authorization": f"Bearer {token}",
+        })
+        assert resp.status_code == 401
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_auth_me_api.py -v
+```
+
+Expected: FAIL
+
+**Step 3: Implement auth dependencies**
+
+```python
+# apps/backend/app/auth/dependencies.py
+"""FastAPI dependencies for authentication."""
+
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.auth.jwt import verify_access_token
+from app.config import settings
+from app.database import db
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> dict:
+    """Extract and validate the current user from Bearer token.
+
+    Returns user dict. Raises 401 if token is missing/invalid.
+    """
+    if not credentials:
+        raise HTTPException(
+            status_code=401,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    try:
+        claims = verify_access_token(
+            credentials.credentials, secret=settings.effective_jwt_secret
+        )
+    except ValueError:
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = await db.get_user_by_id(claims["sub"])
+    if not user:
+        raise HTTPException(
+            status_code=401,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user
+
+
+async def get_optional_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(_bearer_scheme),
+) -> dict | None:
+    """Like get_current_user but returns None instead of raising."""
+    if not credentials:
+        return None
+    try:
+        claims = verify_access_token(
+            credentials.credentials, secret=settings.effective_jwt_secret
+        )
+    except ValueError:
+        return None
+    return await db.get_user_by_id(claims["sub"])
+```
+
+**Step 4: Add /me endpoint to auth.py**
+
+```python
+from fastapi import Depends
+from app.auth.dependencies import get_current_user
+from app.schemas.auth import UserResponse
+
+@router.get("/me", response_model=UserResponse)
+async def me(user: dict = Depends(get_current_user)) -> UserResponse:
+    """Get the current authenticated user's profile."""
+    return UserResponse(
+        id=user["id"],
+        email=user["email"],
+        display_name=user.get("display_name"),
+        is_active=user["is_active"],
+        created_at=user.get("created_at"),
+    )
+```
+
+**Step 5: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_auth_me_api.py -v
+```
+
+Expected: 4 passed
+
+**Step 6: Commit**
+
+```bash
+git add apps/backend/app/auth/dependencies.py apps/backend/app/routers/auth.py apps/backend/tests/integration/test_auth_me_api.py
+git commit -m "feat(m2): add auth dependencies and /me endpoint"
+```
+
+---
+
+### Task 14: OAuth Revoke + Discovery Endpoints (TDD)
+
+**Files:**
+- Modify: `apps/backend/app/routers/oauth.py`
+- Modify: `apps/backend/tests/integration/test_oauth_flow_api.py`
+
+**Step 1: Write failing tests**
+
+Append to `test_oauth_flow_api.py`:
+
+```python
+class TestRevoke:
+    async def test_revoke_clears_session(self, client) -> None:
+        # Login, get refresh cookie
+        await _register_user(client, "revoke@example.com")
+        verifier, challenge = _pkce_pair()
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "revoke@example.com",
+            "password": "password123456",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }, follow_redirects=False)
+        from urllib.parse import parse_qs, urlparse
+        query = parse_qs(urlparse(resp.headers["location"]).query)
+        code = query["code"][0]
+        token_resp = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": verifier,
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+        })
+        # Revoke
+        cookie = token_resp.headers.get("set-cookie", "")
+        token_value = cookie.split("refresh_token=")[1].split(";")[0]
+        client.cookies.set("refresh_token", token_value)
+        revoke_resp = await client.post("/api/v1/oauth/revoke")
+        assert revoke_resp.status_code == 200
+        # Verify cookie is cleared
+        revoke_cookie = revoke_resp.headers.get("set-cookie", "")
+        assert "max-age=0" in revoke_cookie.lower() or 'refresh_token=""' in revoke_cookie
+
+
+class TestDiscovery:
+    async def test_well_known_oauth(self, client) -> None:
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "authorization_endpoint" in data
+        assert "token_endpoint" in data
+        assert "code_challenge_methods_supported" in data
+        assert "S256" in data["code_challenge_methods_supported"]
+        assert "response_types_supported" in data
+        assert "code" in data["response_types_supported"]
+```
+
+**Step 2: Run test to verify it fails**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_oauth_flow_api.py -v -k "Revoke or Discovery"
+```
+
+**Step 3: Implement revoke endpoint in oauth.py**
+
+```python
+@router.post("/revoke")
+async def revoke(request: Request, response: Response) -> dict:
+    """Revoke the current refresh token and clear cookies."""
+    refresh_cookie = request.cookies.get("refresh_token")
+    if refresh_cookie:
+        token_hash = hashlib.sha256(refresh_cookie.encode()).hexdigest()
+        stored = await db.get_refresh_token(token_hash)
+        if stored:
+            await db.revoke_token_family(stored["family_id"])
+
+    response.delete_cookie("refresh_token", path="/api/v1/oauth/token")
+    response.delete_cookie("has_session", path="/")
+    return {"status": "ok"}
+```
+
+**Step 4: Implement discovery endpoint**
+
+Add to `apps/backend/app/main.py` (not under /api/v1 prefix -- must be at root):
+
+```python
+@app.get("/.well-known/oauth-authorization-server")
+async def oauth_server_metadata() -> dict:
+    """RFC 8414 OAuth 2.1 Authorization Server Metadata."""
+    base = settings.frontend_base_url.rstrip("/")
+    api = f"{base}/api/v1"
+    return {
+        "issuer": "resume-matcher",
+        "authorization_endpoint": f"{api}/oauth/authorize",
+        "token_endpoint": f"{api}/oauth/token",
+        "revocation_endpoint": f"{api}/oauth/revoke",
+        "registration_endpoint": None,  # DCR added in M5
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "scopes_supported": ["openid", "profile", "email"],
+    }
+```
+
+**Step 5: Run tests**
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_oauth_flow_api.py -v -k "Revoke or Discovery"
+```
+
+Expected: passed
+
+**Step 6: Commit**
+
+```bash
+git add apps/backend/app/routers/oauth.py apps/backend/app/main.py apps/backend/tests/
+git commit -m "feat(m2): add OAuth revoke endpoint and RFC 8414 discovery"
+```
+
+---
+
+### Task 15: Frontend PKCE + OAuth Utilities
+
+**Files:**
+- Create: `apps/frontend/lib/auth/pkce.ts`
+- Create: `apps/frontend/lib/auth/oauth.ts`
+
+**Step 1: PKCE utility using Web Crypto API**
+
+```typescript
+// apps/frontend/lib/auth/pkce.ts
+
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export async function generatePKCE(): Promise<{
+  codeVerifier: string;
+  codeChallenge: string;
+}> {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  const codeVerifier = base64UrlEncode(array.buffer);
+
+  const encoder = new TextEncoder();
+  const digest = await crypto.subtle.digest('SHA-256', encoder.encode(codeVerifier));
+  const codeChallenge = base64UrlEncode(digest);
+
+  return { codeVerifier, codeChallenge };
+}
+```
+
+**Step 2: OAuth flow helpers**
+
+```typescript
+// apps/frontend/lib/auth/oauth.ts
+
+import { API_BASE, apiFetch } from '@/lib/api/client';
+import { generatePKCE } from './pkce';
+
+const CLIENT_ID = 'resume-matcher-web';
+const REDIRECT_URI =
+  typeof window !== 'undefined'
+    ? `${window.location.origin}/callback`
+    : 'http://localhost:3000/callback';
+
+/** Store PKCE verifier in sessionStorage (survives redirect, cleared on tab close). */
+const VERIFIER_KEY = 'oauth_code_verifier';
+const STATE_KEY = 'oauth_state';
+
+export async function startLogin(): Promise<{
+  codeChallenge: string;
+  codeVerifier: string;
+  state: string;
+}> {
+  const { codeVerifier, codeChallenge } = await generatePKCE();
+  const state = crypto.randomUUID();
+  sessionStorage.setItem(VERIFIER_KEY, codeVerifier);
+  sessionStorage.setItem(STATE_KEY, state);
+  return { codeChallenge, codeVerifier, state };
+}
+
+export async function exchangeCode(code: string): Promise<{
+  access_token: string;
+  expires_in: number;
+}> {
+  const codeVerifier = sessionStorage.getItem(VERIFIER_KEY);
+  if (!codeVerifier) throw new Error('Missing PKCE code_verifier');
+
+  const resp = await apiFetch('/oauth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include', // send/receive cookies
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code,
+      code_verifier: codeVerifier,
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT_URI,
+    }),
+  });
+
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throw new Error(err.detail || 'Token exchange failed');
+  }
+
+  // Clean up
+  sessionStorage.removeItem(VERIFIER_KEY);
+  sessionStorage.removeItem(STATE_KEY);
+
+  return resp.json();
+}
+
+export async function silentRefresh(): Promise<{
+  access_token: string;
+  expires_in: number;
+} | null> {
+  try {
+    const resp = await apiFetch('/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ grant_type: 'refresh_token' }),
+    });
+    if (!resp.ok) return null;
+    return resp.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function logout(): Promise<void> {
+  await apiFetch('/oauth/revoke', {
+    method: 'POST',
+    credentials: 'include',
+  });
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/frontend/lib/auth/
+git commit -m "feat(m2): add frontend PKCE and OAuth flow utilities"
+```
+
+---
+
+### Task 16: Frontend Auth Context
+
+**Files:**
+- Create: `apps/frontend/lib/auth/context.tsx`
+
+**Step 1: Create AuthProvider**
+
+```tsx
+// apps/frontend/lib/auth/context.tsx
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { silentRefresh, logout as oauthLogout } from './oauth';
+import { apiFetch } from '@/lib/api/client';
+
+interface User {
+  id: string;
+  email: string;
+  display_name: string | null;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  isLoading: boolean;
+  getToken: () => Promise<string | null>;
+  login: () => void;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const tokenRef = useRef<string | null>(null);
+  const expiresAtRef = useRef<number>(0);
+
+  const setToken = useCallback((token: string, expiresIn: number) => {
+    tokenRef.current = token;
+    // Refresh 60s before actual expiry
+    expiresAtRef.current = Date.now() + (expiresIn - 60) * 1000;
+  }, []);
+
+  const fetchUser = useCallback(async (token: string) => {
+    const resp = await apiFetch('/auth/me', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (resp.ok) {
+      setUser(await resp.json());
+    } else {
+      setUser(null);
+    }
+  }, []);
+
+  const getToken = useCallback(async (): Promise<string | null> => {
+    if (tokenRef.current && Date.now() < expiresAtRef.current) {
+      return tokenRef.current;
+    }
+    // Token expired or missing -- try silent refresh
+    const result = await silentRefresh();
+    if (result) {
+      setToken(result.access_token, result.expires_in);
+      return result.access_token;
+    }
+    tokenRef.current = null;
+    setUser(null);
+    return null;
+  }, [setToken]);
+
+  const login = useCallback(() => {
+    window.location.href = '/login';
+  }, []);
+
+  const logout = useCallback(async () => {
+    await oauthLogout();
+    tokenRef.current = null;
+    expiresAtRef.current = 0;
+    setUser(null);
+  }, []);
+
+  // On mount: attempt silent refresh
+  useEffect(() => {
+    (async () => {
+      const result = await silentRefresh();
+      if (result) {
+        setToken(result.access_token, result.expires_in);
+        await fetchUser(result.access_token);
+      }
+      setIsLoading(false);
+    })();
+  }, [setToken, fetchUser]);
+
+  return (
+    <AuthContext value={{ user, isLoading, getToken, login, logout }}>
+      {children}
+    </AuthContext>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}
+```
+
+**Step 2: Wrap app with AuthProvider**
+
+In `apps/frontend/app/(default)/layout.tsx`, add the `AuthProvider` around existing providers:
+
+```tsx
+import { AuthProvider } from '@/lib/auth/context';
+
+export default function DefaultLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <AuthProvider>
+      <StatusCacheProvider>
+        {/* ... existing providers ... */}
+      </StatusCacheProvider>
+    </AuthProvider>
+  );
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/frontend/lib/auth/context.tsx apps/frontend/app/\(default\)/layout.tsx
+git commit -m "feat(m2): add AuthProvider context with silent refresh"
+```
+
+---
+
+### Task 17: Frontend Login Page
+
+**Files:**
+- Create: `apps/frontend/app/(auth)/login/page.tsx`
+- Create: `apps/frontend/components/auth/login-form.tsx`
+
+**Step 1: Create login form component**
+
+The login form collects email + password, then POSTs to the OAuth authorize endpoint with PKCE params from the URL query string.
+
+```tsx
+// apps/frontend/components/auth/login-form.tsx
+'use client';
+
+import { useState } from 'react';
+import { apiPost } from '@/lib/api/client';
+
+interface LoginFormProps {
+  codeChallenge: string;
+  state: string;
+}
+
+export function LoginForm({ codeChallenge, state }: LoginFormProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const redirectUri = `${window.location.origin}/callback`;
+    const resp = await apiPost('/oauth/authorize', {
+      email,
+      password,
+      client_id: 'resume-matcher-web',
+      redirect_uri: redirectUri,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      state,
+    });
+
+    if (resp.status === 303 || resp.redirected) {
+      // Follow redirect to callback with code
+      const location = resp.headers.get('location');
+      if (location) {
+        window.location.href = location;
+        return;
+      }
+    }
+
+    // Handle error
+    setLoading(false);
+    if (resp.status === 401) {
+      setError('Invalid email or password');
+    } else {
+      const data = await resp.json().catch(() => ({}));
+      setError(data.detail || 'Login failed');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter') e.stopPropagation();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="border border-[#DC2626] bg-red-50 p-3 font-sans text-sm text-[#DC2626]">
+          {error}
+        </div>
+      )}
+      <div>
+        <label htmlFor="email" className="block font-mono text-xs uppercase tracking-wider mb-1">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="w-full border border-black bg-white px-3 py-2 font-sans text-sm focus:outline-none focus:ring-1 focus:ring-black rounded-none"
+        />
+      </div>
+      <div>
+        <label htmlFor="password" className="block font-mono text-xs uppercase tracking-wider mb-1">
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={8}
+          className="w-full border border-black bg-white px-3 py-2 font-sans text-sm focus:outline-none focus:ring-1 focus:ring-black rounded-none"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full border border-black bg-black text-white px-4 py-2 font-sans text-sm hover:bg-gray-900 disabled:opacity-50 rounded-none"
+      >
+        {loading ? 'Signing in...' : 'Sign in'}
+      </button>
+      <p className="text-center font-sans text-sm text-gray-600">
+        No account?{' '}
+        <a href="/register" className="text-[#1D4ED8] underline">
+          Register
+        </a>
+      </p>
+    </form>
+  );
+}
+```
+
+**Step 2: Create login page**
+
+```tsx
+// apps/frontend/app/(auth)/login/page.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { LoginForm } from '@/components/auth/login-form';
+import { startLogin } from '@/lib/auth/oauth';
+
+export default function LoginPage() {
+  const [pkce, setPkce] = useState<{ codeChallenge: string; state: string } | null>(null);
+
+  useEffect(() => {
+    startLogin().then(({ codeChallenge, state }) => {
+      setPkce({ codeChallenge, state });
+    });
+  }, []);
+
+  if (!pkce) return null; // loading PKCE
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#F0F0E8]">
+      <div className="w-full max-w-sm border border-black bg-white p-8 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+        <h1 className="mb-6 font-serif text-2xl font-bold">Sign In</h1>
+        <LoginForm codeChallenge={pkce.codeChallenge} state={pkce.state} />
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/frontend/app/\(auth\)/ apps/frontend/components/auth/
+git commit -m "feat(m2): add login page with Swiss International Style"
+```
+
+---
+
+### Task 18: Frontend Register Page
+
+**Files:**
+- Create: `apps/frontend/app/(auth)/register/page.tsx`
+- Create: `apps/frontend/components/auth/register-form.tsx`
+
+**Step 1: Create register form**
+
+```tsx
+// apps/frontend/components/auth/register-form.tsx
+'use client';
+
+import { useState } from 'react';
+import { apiPost } from '@/lib/api/client';
+
+export function RegisterForm() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    const resp = await apiPost('/auth/register', {
+      email,
+      password,
+      display_name: displayName || undefined,
+    });
+
+    if (resp.status === 201) {
+      // Registration successful -- redirect to login
+      window.location.href = '/login';
+      return;
+    }
+
+    setLoading(false);
+    const data = await resp.json().catch(() => ({}));
+    if (resp.status === 409) {
+      setError('An account with this email already exists');
+    } else {
+      setError(data.detail || 'Registration failed');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {error && (
+        <div className="border border-[#DC2626] bg-red-50 p-3 font-sans text-sm text-[#DC2626]">
+          {error}
+        </div>
+      )}
+      <div>
+        <label htmlFor="displayName" className="block font-mono text-xs uppercase tracking-wider mb-1">
+          Name (optional)
+        </label>
+        <input
+          id="displayName"
+          type="text"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          className="w-full border border-black bg-white px-3 py-2 font-sans text-sm focus:outline-none focus:ring-1 focus:ring-black rounded-none"
+        />
+      </div>
+      <div>
+        <label htmlFor="email" className="block font-mono text-xs uppercase tracking-wider mb-1">
+          Email
+        </label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="w-full border border-black bg-white px-3 py-2 font-sans text-sm focus:outline-none focus:ring-1 focus:ring-black rounded-none"
+        />
+      </div>
+      <div>
+        <label htmlFor="password" className="block font-mono text-xs uppercase tracking-wider mb-1">
+          Password
+        </label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          minLength={8}
+          className="w-full border border-black bg-white px-3 py-2 font-sans text-sm focus:outline-none focus:ring-1 focus:ring-black rounded-none"
+        />
+        <p className="mt-1 font-mono text-xs text-gray-500">Minimum 8 characters</p>
+      </div>
+      <button
+        type="submit"
+        disabled={loading}
+        className="w-full border border-black bg-black text-white px-4 py-2 font-sans text-sm hover:bg-gray-900 disabled:opacity-50 rounded-none"
+      >
+        {loading ? 'Creating account...' : 'Create account'}
+      </button>
+      <p className="text-center font-sans text-sm text-gray-600">
+        Already have an account?{' '}
+        <a href="/login" className="text-[#1D4ED8] underline">
+          Sign in
+        </a>
+      </p>
+    </form>
+  );
+}
+```
+
+**Step 2: Create register page**
+
+```tsx
+// apps/frontend/app/(auth)/register/page.tsx
+import { RegisterForm } from '@/components/auth/register-form';
+
+export default function RegisterPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#F0F0E8]">
+      <div className="w-full max-w-sm border border-black bg-white p-8 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+        <h1 className="mb-6 font-serif text-2xl font-bold">Create Account</h1>
+        <RegisterForm />
+      </div>
+    </div>
+  );
+}
+```
+
+**Step 3: Commit**
+
+```bash
+git add apps/frontend/app/\(auth\)/register/ apps/frontend/components/auth/register-form.tsx
+git commit -m "feat(m2): add registration page with Swiss International Style"
+```
+
+---
+
+### Task 19: Frontend Callback + API Client Auth Injection
+
+**Files:**
+- Create: `apps/frontend/app/(auth)/callback/page.tsx`
+- Modify: `apps/frontend/lib/api/client.ts`
+
+**Step 1: Create callback page**
+
+```tsx
+// apps/frontend/app/(auth)/callback/page.tsx
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { exchangeCode } from '@/lib/auth/oauth';
+
+export default function CallbackPage() {
+  const params = useSearchParams();
+  const exchanged = useRef(false);
+
+  useEffect(() => {
+    if (exchanged.current) return;
+    exchanged.current = true;
+
+    const code = params.get('code');
+    const state = params.get('state');
+    const savedState = sessionStorage.getItem('oauth_state');
+
+    if (!code) {
+      window.location.href = '/login';
+      return;
+    }
+
+    // Validate state to prevent CSRF
+    if (state && savedState && state !== savedState) {
+      window.location.href = '/login';
+      return;
+    }
+
+    exchangeCode(code)
+      .then(() => {
+        window.location.href = '/';
+      })
+      .catch(() => {
+        window.location.href = '/login';
+      });
+  }, [params]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#F0F0E8]">
+      <p className="font-sans text-sm text-gray-600">Completing sign in...</p>
+    </div>
+  );
+}
+```
+
+**Step 2: Add auth header injection to API client**
+
+Add to `apps/frontend/lib/api/client.ts`:
+
+```typescript
+/**
+ * Token getter function -- set by AuthProvider.
+ * Returns a valid access token or null.
+ */
+let _getToken: (() => Promise<string | null>) | null = null;
+
+export function setTokenGetter(fn: () => Promise<string | null>): void {
+  _getToken = fn;
+}
+
+/**
+ * Authenticated fetch: injects Authorization header if token available.
+ */
+export async function authFetch(
+  endpoint: string,
+  options?: RequestInit,
+  timeoutMs?: number
+): Promise<Response> {
+  const token = _getToken ? await _getToken() : null;
+  const headers = new Headers(options?.headers);
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return apiFetch(endpoint, { ...options, headers, credentials: 'include' }, timeoutMs);
+}
+```
+
+Then update `AuthProvider` in `context.tsx` to call `setTokenGetter(getToken)` on mount.
+
+**Step 3: Commit**
+
+```bash
+git add apps/frontend/app/\(auth\)/callback/ apps/frontend/lib/api/client.ts apps/frontend/lib/auth/context.tsx
+git commit -m "feat(m2): add OAuth callback page and authenticated fetch"
+```
+
+---
+
+### Task 20: Frontend User Menu + Middleware
+
+**Files:**
+- Create: `apps/frontend/components/auth/user-menu.tsx`
+- Create: `apps/frontend/middleware.ts`
+
+**Step 1: Create user menu component**
+
+```tsx
+// apps/frontend/components/auth/user-menu.tsx
+'use client';
+
+import { useAuth } from '@/lib/auth/context';
+
+export function UserMenu() {
+  const { user, isLoading, login, logout } = useAuth();
+
+  if (isLoading) return null;
+
+  if (!user) {
+    return (
+      <button
+        onClick={login}
+        className="border border-black px-3 py-1 font-sans text-sm hover:bg-black hover:text-white rounded-none"
+      >
+        Sign in
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      <span className="font-mono text-xs">{user.display_name || user.email}</span>
+      <button
+        onClick={logout}
+        className="border border-black px-3 py-1 font-sans text-sm hover:bg-black hover:text-white rounded-none"
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}
+```
+
+**Step 2: Wire user menu into existing navigation**
+
+Find the existing header/navigation component and add `<UserMenu />` to it. The exact file depends on the current nav component -- check `apps/frontend/components/` for the header.
+
+**Step 3: Create route protection middleware**
+
+```typescript
+// apps/frontend/middleware.ts
+import { NextRequest, NextResponse } from 'next/server';
+
+// Routes that require authentication (enforced in M4, soft-redirect for now)
+const PROTECTED_ROUTES: string[] = [];
+// Routes that are only for unauthenticated users
+const AUTH_ROUTES = ['/login', '/register', '/callback'];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const hasSession = request.cookies.get('has_session')?.value === '1';
+
+  // Redirect authenticated users away from auth pages
+  if (hasSession && AUTH_ROUTES.some((r) => pathname.startsWith(r))) {
+    return NextResponse.redirect(new URL('/', request.url));
+  }
+
+  // Future: redirect unauthenticated users from protected routes
+  // Currently all routes are public (M4 will enforce)
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+};
+```
+
+**Step 4: Run frontend linting**
+
+```bash
+cd apps/frontend && npm run lint && npm run format
+```
+
+**Step 5: Commit**
+
+```bash
+git add apps/frontend/components/auth/ apps/frontend/middleware.ts
+git commit -m "feat(m2): add user menu and route protection middleware"
+```
+
+---
+
+### Task 21: Final Integration + Alembic Migration
+
+**Files:**
+- Verify: all routers registered in `main.py`
+- Generate: Alembic migration for auth tables
+- Run: full test suite
+
+**Step 1: Verify main.py has all routers**
+
+Ensure `main.py` includes:
+```python
+app.include_router(auth_router, prefix="/api/v1")
+app.include_router(oauth_router, prefix="/api/v1")
+```
+
+And the `/.well-known/oauth-authorization-server` endpoint is at root level.
+
+**Step 2: Generate and run migration**
+
+```bash
+cd apps/backend && uv run alembic revision --autogenerate -m "add auth tables"
+cd apps/backend && uv run alembic upgrade head
+```
+
+**Step 3: Run full backend test suite**
+
+```bash
+cd apps/backend && uv run pytest tests/ -v --tb=short
+```
+
+Expected: all tests pass (existing + new auth tests)
+
+**Step 4: Run frontend build**
+
+```bash
+cd apps/frontend && npm run build
+```
+
+**Step 5: Manual smoke test**
+
+1. Start backend: `cd apps/backend && uv run uvicorn app.main:app --reload --port 8000`
+2. Start frontend: `cd apps/frontend && npm run dev`
+3. Navigate to `http://localhost:3000/register` -- create account
+4. Navigate to `http://localhost:3000/login` -- sign in
+5. Verify redirect to `/` with user menu showing
+6. Refresh page -- verify silent refresh keeps user logged in
+7. Click "Sign out" -- verify logout and redirect
+8. Check `http://localhost:8000/.well-known/oauth-authorization-server` returns metadata
+
+**Step 6: Final commit**
+
+```bash
+git add -A
+git commit -m "feat(m2): complete OAuth 2.1 authorization server with frontend auth flow"
+```
+
+---
+
+## Summary
+
+| Task | What | Tests |
+|------|------|-------|
+| 1 | Dependencies (authlib, joserfc, argon2-cffi) | -- |
+| 2 | Auth constants + JWT config | -- |
+| 3 | AuthorizationCode + RefreshToken models + migration | 5 |
+| 4 | Password module (argon2id) | 6 |
+| 5 | JWT module (joserfc) | 7 |
+| 6 | PKCE module (S256) | 5 |
+| 7 | Database user CRUD | 7 |
+| 8 | Database auth code + refresh token CRUD | 7 |
+| 9 | Auth Pydantic schemas | -- |
+| 10 | Registration endpoint | 5 |
+| 11 | OAuth authorize endpoint | 5 |
+| 12 | OAuth token endpoint (exchange + refresh) | 5 |
+| 13 | Auth dependencies + /me | 4 |
+| 14 | Revoke + discovery endpoints | 2 |
+| 15 | Frontend PKCE + OAuth utilities | -- |
+| 16 | Frontend AuthProvider context | -- |
+| 17 | Frontend login page | -- |
+| 18 | Frontend register page | -- |
+| 19 | Frontend callback + auth fetch | -- |
+| 20 | Frontend user menu + middleware | -- |
+| 21 | Final integration + migration | all |
+
+**Total backend tests: ~58 new tests**

--- a/docs/plans/2026-04-03-m3-google-oauth-provider.md
+++ b/docs/plans/2026-04-03-m3-google-oauth-provider.md
@@ -1,0 +1,1776 @@
+# M3: Google OAuth Provider Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add "Sign in with Google" as the first external identity provider, integrated with the existing OAuth 2.1 authorization server from M2.
+
+**Architecture:** Google OAuth uses parallel endpoints (`/oauth/google/start`, `/oauth/google/callback`) that produce a standard authorization code feeding through the existing `/oauth/token` PKCE exchange. HMAC-signed packed state carries the frontend's PKCE params through Google's redirect. A new `oauth_accounts` table supports multiple providers. Auto-linking by verified email, with password-proof gate for existing password accounts.
+
+**Tech Stack:** httpx (Google token exchange), authlib (already a dep), joserfc (existing JWT), SQLAlchemy 2.0 async (existing ORM), Next.js 16 (frontend)
+
+---
+
+## Prerequisites
+
+- M2 (OAuth 2.1) merged on `fork/main`
+- Google Cloud Console project with OAuth 2.0 credentials (client ID + secret)
+- Backend `.env` will need `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+
+---
+
+## Task 1: OAuthAccount Model + Alembic Migration
+
+**Files:**
+- Modify: `apps/backend/app/models.py`
+- Create: `apps/backend/alembic/versions/xxxx_add_oauth_accounts_table.py`
+
+**Step 1: Add OAuthAccount model to models.py**
+
+Add after the `RefreshToken` class at the end of `models.py`:
+
+```python
+from sqlalchemy import UniqueConstraint
+
+class OAuthAccount(Base):
+    __tablename__ = "oauth_accounts"
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
+    user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
+    provider: Mapped[str] = mapped_column(String(50))
+    provider_user_id: Mapped[str] = mapped_column(String(255))
+    provider_email: Mapped[str | None] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("provider", "provider_user_id", name="uq_oauth_provider_user"),
+    )
+```
+
+Note: `UniqueConstraint` import needs to be added to the existing import line from `sqlalchemy`.
+
+**Step 2: Generate Alembic migration**
+
+```bash
+cd apps/backend && uv run alembic revision --autogenerate -m "add_oauth_accounts_table"
+```
+
+Verify the generated migration creates the `oauth_accounts` table with the unique constraint.
+
+**Step 3: Run the migration to verify**
+
+```bash
+cd apps/backend && uv run alembic upgrade head
+```
+
+Expected: No errors, `oauth_accounts` table created.
+
+**Step 4: Commit**
+
+```bash
+git add apps/backend/app/models.py apps/backend/alembic/versions/*oauth_accounts*
+git commit -m "feat(m3): add OAuthAccount model and migration"
+```
+
+---
+
+## Task 2: OAuthAccount Database CRUD + Tests
+
+**Files:**
+- Modify: `apps/backend/app/database.py`
+- Create: `apps/backend/tests/unit/test_oauth_account_database.py`
+
+**Step 1: Write the failing tests**
+
+Create `tests/unit/test_oauth_account_database.py`:
+
+```python
+"""Unit tests for OAuthAccount database operations."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.database import Database
+
+
+@pytest.fixture
+async def db():
+    database = Database("sqlite+aiosqlite://")
+    await database.init()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def user(db):
+    return await db.create_user(
+        email="test@example.com",
+        hashed_password="hashed",
+        display_name="Test User",
+    )
+
+
+class TestOAuthAccountCRUD:
+    async def test_create_oauth_account(self, db, user) -> None:
+        account = await db.create_oauth_account(
+            user_id=user["id"],
+            provider="google",
+            provider_user_id="google-123",
+            provider_email="test@gmail.com",
+        )
+        assert account["user_id"] == user["id"]
+        assert account["provider"] == "google"
+        assert account["provider_user_id"] == "google-123"
+        assert account["provider_email"] == "test@gmail.com"
+        assert "id" in account
+        assert "created_at" in account
+
+    async def test_get_oauth_account_by_provider(self, db, user) -> None:
+        await db.create_oauth_account(
+            user_id=user["id"],
+            provider="google",
+            provider_user_id="google-456",
+        )
+        result = await db.get_oauth_account("google", "google-456")
+        assert result is not None
+        assert result["user_id"] == user["id"]
+
+    async def test_get_oauth_account_not_found(self, db) -> None:
+        result = await db.get_oauth_account("google", "nonexistent")
+        assert result is None
+
+    async def test_duplicate_oauth_account_raises(self, db, user) -> None:
+        await db.create_oauth_account(
+            user_id=user["id"],
+            provider="google",
+            provider_user_id="google-789",
+        )
+        with pytest.raises(IntegrityError):
+            await db.create_oauth_account(
+                user_id=user["id"],
+                provider="google",
+                provider_user_id="google-789",
+            )
+
+    async def test_get_oauth_accounts_by_user(self, db, user) -> None:
+        await db.create_oauth_account(
+            user_id=user["id"],
+            provider="google",
+            provider_user_id="g-1",
+        )
+        await db.create_oauth_account(
+            user_id=user["id"],
+            provider="github",
+            provider_user_id="gh-1",
+        )
+        accounts = await db.get_oauth_accounts_by_user(user["id"])
+        assert len(accounts) == 2
+        providers = {a["provider"] for a in accounts}
+        assert providers == {"google", "github"}
+
+    async def test_same_provider_different_users(self, db) -> None:
+        user1 = await db.create_user(email="a@example.com", hashed_password="h")
+        user2 = await db.create_user(email="b@example.com", hashed_password="h")
+        await db.create_oauth_account(
+            user_id=user1["id"], provider="google", provider_user_id="g-a"
+        )
+        await db.create_oauth_account(
+            user_id=user2["id"], provider="google", provider_user_id="g-b"
+        )
+        assert await db.get_oauth_account("google", "g-a") is not None
+        assert await db.get_oauth_account("google", "g-b") is not None
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_oauth_account_database.py -v
+```
+
+Expected: FAIL — `create_oauth_account` method does not exist.
+
+**Step 3: Implement database CRUD methods**
+
+Add to `database.py` after the `_refresh_token_to_dict` method:
+
+1. Add `OAuthAccount` to the import line:
+```python
+from app.models import AuthorizationCode, Base, Improvement, Job, OAuthAccount, RefreshToken, Resume, User
+```
+
+2. Add the to_dict method and CRUD operations:
+```python
+    @staticmethod
+    def _oauth_account_to_dict(o: OAuthAccount) -> dict[str, Any]:
+        return {
+            "id": o.id,
+            "user_id": o.user_id,
+            "provider": o.provider,
+            "provider_user_id": o.provider_user_id,
+            "provider_email": o.provider_email,
+            "created_at": o.created_at.isoformat() if o.created_at else None,
+        }
+
+    # -- OAuth account operations -----------------------------------------------
+
+    async def create_oauth_account(
+        self,
+        user_id: str,
+        provider: str,
+        provider_user_id: str,
+        provider_email: str | None = None,
+    ) -> dict[str, Any]:
+        account = OAuthAccount(
+            id=str(uuid4()),
+            user_id=user_id,
+            provider=provider,
+            provider_user_id=provider_user_id,
+            provider_email=provider_email,
+        )
+        async with self._session() as session:
+            session.add(account)
+            await session.commit()
+            await session.refresh(account)
+            return self._oauth_account_to_dict(account)
+
+    async def get_oauth_account(
+        self,
+        provider: str,
+        provider_user_id: str,
+    ) -> dict[str, Any] | None:
+        async with self._session() as session:
+            result = await session.execute(
+                select(OAuthAccount).where(
+                    OAuthAccount.provider == provider,
+                    OAuthAccount.provider_user_id == provider_user_id,
+                )
+            )
+            row = result.scalar_one_or_none()
+            return self._oauth_account_to_dict(row) if row else None
+
+    async def get_oauth_accounts_by_user(
+        self,
+        user_id: str,
+    ) -> list[dict[str, Any]]:
+        async with self._session() as session:
+            result = await session.execute(
+                select(OAuthAccount).where(OAuthAccount.user_id == user_id)
+            )
+            return [self._oauth_account_to_dict(o) for o in result.scalars().all()]
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_oauth_account_database.py -v
+```
+
+Expected: All 6 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/database.py tests/unit/test_oauth_account_database.py
+git commit -m "feat(m3): add OAuthAccount database CRUD with tests"
+```
+
+---
+
+## Task 3: Config Additions + Optional Password for create_user
+
+**Files:**
+- Modify: `apps/backend/app/config.py:160-162`
+- Modify: `apps/backend/app/database.py:109-114`
+
+**Step 1: Add Google config to Settings class**
+
+In `config.py`, after the `frontend_origin` field (line ~162), add:
+
+```python
+    # Google OAuth
+    google_client_id: str = ""
+    google_client_secret: str = ""
+```
+
+**Step 2: Make create_user accept optional hashed_password**
+
+In `database.py`, change the `create_user` signature from:
+
+```python
+    async def create_user(
+        self,
+        email: str,
+        hashed_password: str,
+        display_name: str | None = None,
+    ) -> dict[str, Any]:
+```
+
+To:
+
+```python
+    async def create_user(
+        self,
+        email: str,
+        hashed_password: str | None = None,
+        display_name: str | None = None,
+    ) -> dict[str, Any]:
+```
+
+**Step 3: Verify existing tests still pass**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/ -v
+```
+
+Expected: All existing tests PASS (registration endpoint still passes hashed_password explicitly).
+
+**Step 4: Commit**
+
+```bash
+git add apps/backend/app/config.py apps/backend/app/database.py
+git commit -m "feat(m3): add Google OAuth config and optional password for create_user"
+```
+
+---
+
+## Task 4: State Packing/Unpacking + Tests
+
+**Files:**
+- Create: `apps/backend/app/auth/google.py`
+- Create: `apps/backend/tests/unit/test_google_state.py`
+
+**Step 1: Write the failing tests**
+
+Create `tests/unit/test_google_state.py`:
+
+```python
+"""Unit tests for Google OAuth state packing/unpacking."""
+
+import time
+
+import pytest
+
+from app.auth.google import pack_state, unpack_state
+
+
+SECRET = "test-secret-key-for-hmac"
+
+
+class TestStatePacking:
+    def test_roundtrip(self) -> None:
+        data = {
+            "state": "abc-123",
+            "code_challenge": "challenge",
+            "redirect_uri": "http://localhost:3000/callback",
+            "nonce": "nonce-value",
+            "ts": int(time.time()),
+        }
+        packed = pack_state(data, SECRET)
+        result = unpack_state(packed, SECRET)
+        assert result["state"] == "abc-123"
+        assert result["code_challenge"] == "challenge"
+        assert result["nonce"] == "nonce-value"
+
+    def test_tampered_payload_rejected(self) -> None:
+        data = {"state": "original", "ts": int(time.time())}
+        packed = pack_state(data, SECRET)
+        payload, sig = packed.rsplit(".", 1)
+        tampered = payload[:-1] + ("A" if payload[-1] != "A" else "B")
+        with pytest.raises(ValueError, match="Invalid state signature"):
+            unpack_state(f"{tampered}.{sig}", SECRET)
+
+    def test_tampered_signature_rejected(self) -> None:
+        data = {"state": "original", "ts": int(time.time())}
+        packed = pack_state(data, SECRET)
+        with pytest.raises(ValueError, match="Invalid state signature"):
+            unpack_state(packed + "x", SECRET)
+
+    def test_expired_state_rejected(self) -> None:
+        data = {"state": "old", "ts": int(time.time()) - 700}
+        packed = pack_state(data, SECRET)
+        with pytest.raises(ValueError, match="State expired"):
+            unpack_state(packed, SECRET, max_age=600)
+
+    def test_wrong_secret_rejected(self) -> None:
+        data = {"state": "test", "ts": int(time.time())}
+        packed = pack_state(data, SECRET)
+        with pytest.raises(ValueError, match="Invalid state signature"):
+            unpack_state(packed, "wrong-secret")
+
+    def test_malformed_state_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Malformed state"):
+            unpack_state("no-dot-separator", SECRET)
+
+    def test_fresh_state_accepted(self) -> None:
+        data = {"state": "fresh", "ts": int(time.time()) - 300}
+        packed = pack_state(data, SECRET)
+        result = unpack_state(packed, SECRET, max_age=600)
+        assert result["state"] == "fresh"
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_google_state.py -v
+```
+
+Expected: FAIL — `app.auth.google` module does not exist.
+
+**Step 3: Implement state packing/unpacking**
+
+Create `apps/backend/app/auth/google.py`:
+
+```python
+"""Google OAuth 2.0 helpers: state packing, token exchange, user resolution."""
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import time
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Google endpoints
+GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
+GOOGLE_SCOPES = "openid email profile"
+
+
+# ---------------------------------------------------------------------------
+# State packing (HMAC-signed, stateless)
+# ---------------------------------------------------------------------------
+
+def pack_state(data: dict, secret: str) -> str:
+    """Pack OAuth state dict with HMAC-SHA256 integrity protection."""
+    payload = base64.urlsafe_b64encode(json.dumps(data).encode()).decode().rstrip("=")
+    sig = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    return f"{payload}.{sig}"
+
+
+def unpack_state(packed: str, secret: str, max_age: int = 600) -> dict:
+    """Unpack and verify HMAC-signed state. Raises ValueError on failure."""
+    try:
+        payload, sig = packed.rsplit(".", 1)
+    except ValueError:
+        raise ValueError("Malformed state")
+
+    expected = hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(sig, expected):
+        raise ValueError("Invalid state signature")
+
+    # Restore base64 padding
+    padding = 4 - len(payload) % 4
+    if padding != 4:
+        payload += "=" * padding
+
+    data = json.loads(base64.urlsafe_b64decode(payload))
+
+    if time.time() - data.get("ts", 0) > max_age:
+        raise ValueError("State expired")
+
+    return data
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_google_state.py -v
+```
+
+Expected: All 7 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/auth/google.py tests/unit/test_google_state.py
+git commit -m "feat(m3): add HMAC-signed state packing for Google OAuth"
+```
+
+---
+
+## Task 5: Google Token Exchange + ID Token Validation + Tests
+
+**Files:**
+- Modify: `apps/backend/app/auth/google.py`
+- Create: `apps/backend/tests/unit/test_google_token.py`
+
+**Step 1: Write the failing tests**
+
+Create `tests/unit/test_google_token.py`:
+
+```python
+"""Unit tests for Google token exchange and ID token validation."""
+
+import base64
+import json
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.auth.google import (
+    exchange_google_code,
+    parse_id_token,
+    validate_id_token_claims,
+)
+
+
+def _make_jwt_payload(claims: dict) -> str:
+    """Build a fake JWT with the given payload (no signature verification needed)."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    sig = base64.urlsafe_b64encode(b"fakesig").decode().rstrip("=")
+    return f"{header}.{payload}.{sig}"
+
+
+class TestParseIdToken:
+    def test_parse_valid_token(self) -> None:
+        claims = {"sub": "123", "email": "test@gmail.com", "iss": "https://accounts.google.com"}
+        token = _make_jwt_payload(claims)
+        result = parse_id_token(token)
+        assert result["sub"] == "123"
+        assert result["email"] == "test@gmail.com"
+
+    def test_parse_invalid_format(self) -> None:
+        with pytest.raises(ValueError, match="Invalid ID token format"):
+            parse_id_token("not.a.valid.jwt.token")
+
+    def test_parse_too_few_parts(self) -> None:
+        with pytest.raises(ValueError, match="Invalid ID token format"):
+            parse_id_token("onlyonepart")
+
+
+class TestValidateIdTokenClaims:
+    def _valid_claims(self, **overrides) -> dict:
+        claims = {
+            "iss": "https://accounts.google.com",
+            "aud": "my-client-id",
+            "exp": int(time.time()) + 300,
+            "nonce": "expected-nonce",
+            "sub": "google-user-123",
+            "email": "user@gmail.com",
+            "email_verified": True,
+        }
+        claims.update(overrides)
+        return claims
+
+    def test_valid_claims_pass(self) -> None:
+        claims = self._valid_claims()
+        result = validate_id_token_claims(claims, "my-client-id", "expected-nonce")
+        assert result["sub"] == "google-user-123"
+
+    def test_wrong_issuer(self) -> None:
+        claims = self._valid_claims(iss="https://evil.com")
+        with pytest.raises(ValueError, match="Invalid issuer"):
+            validate_id_token_claims(claims, "my-client-id", "expected-nonce")
+
+    def test_accounts_google_com_issuer_accepted(self) -> None:
+        claims = self._valid_claims(iss="accounts.google.com")
+        result = validate_id_token_claims(claims, "my-client-id", "expected-nonce")
+        assert result["sub"] == "google-user-123"
+
+    def test_wrong_audience(self) -> None:
+        claims = self._valid_claims(aud="wrong-client")
+        with pytest.raises(ValueError, match="Audience mismatch"):
+            validate_id_token_claims(claims, "my-client-id", "expected-nonce")
+
+    def test_expired_token(self) -> None:
+        claims = self._valid_claims(exp=int(time.time()) - 100)
+        with pytest.raises(ValueError, match="ID token expired"):
+            validate_id_token_claims(claims, "my-client-id", "expected-nonce")
+
+    def test_wrong_nonce(self) -> None:
+        claims = self._valid_claims(nonce="wrong-nonce")
+        with pytest.raises(ValueError, match="Nonce mismatch"):
+            validate_id_token_claims(claims, "my-client-id", "expected-nonce")
+
+
+class TestExchangeGoogleCode:
+    async def test_successful_exchange(self) -> None:
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "at",
+            "id_token": "fake.jwt.token",
+            "token_type": "Bearer",
+        }
+        mock_response.raise_for_status = AsyncMock()
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.auth.google.httpx.AsyncClient", return_value=mock_client):
+            result = await exchange_google_code(
+                code="auth-code",
+                redirect_uri="http://localhost:8000/api/v1/oauth/google/callback",
+                client_id="cid",
+                client_secret="csecret",
+            )
+        assert result["id_token"] == "fake.jwt.token"
+
+    async def test_failed_exchange(self) -> None:
+        mock_response = AsyncMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.auth.google.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(ValueError, match="Google token exchange failed"):
+                await exchange_google_code(
+                    code="bad-code",
+                    redirect_uri="http://localhost:8000/callback",
+                    client_id="cid",
+                    client_secret="csecret",
+                )
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_google_token.py -v
+```
+
+Expected: FAIL — functions not defined.
+
+**Step 3: Implement token exchange and ID token validation**
+
+Add to `apps/backend/app/auth/google.py` after the state packing section:
+
+```python
+# ---------------------------------------------------------------------------
+# Google token exchange
+# ---------------------------------------------------------------------------
+
+async def exchange_google_code(
+    code: str,
+    redirect_uri: str,
+    client_id: str,
+    client_secret: str,
+) -> dict:
+    """Exchange Google authorization code for tokens (including id_token)."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(GOOGLE_TOKEN_URL, data={
+            "code": code,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+            "grant_type": "authorization_code",
+        })
+        if resp.status_code != 200:
+            raise ValueError(f"Google token exchange failed: {resp.status_code}")
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# ID token parsing and validation
+# ---------------------------------------------------------------------------
+
+def parse_id_token(id_token: str) -> dict:
+    """Decode JWT payload without signature verification.
+
+    Safe because the token comes directly from Google's token endpoint
+    over HTTPS (trusted channel).
+    """
+    parts = id_token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Invalid ID token format")
+    payload = parts[1]
+    # Restore base64 padding
+    padding = 4 - len(payload) % 4
+    if padding != 4:
+        payload += "=" * padding
+    return json.loads(base64.urlsafe_b64decode(payload))
+
+
+def validate_id_token_claims(
+    claims: dict,
+    expected_aud: str,
+    expected_nonce: str,
+) -> dict:
+    """Validate Google ID token claims. Raises ValueError on failure."""
+    valid_issuers = ("https://accounts.google.com", "accounts.google.com")
+    if claims.get("iss") not in valid_issuers:
+        raise ValueError(f"Invalid issuer: {claims.get('iss')}")
+    if claims.get("aud") != expected_aud:
+        raise ValueError("Audience mismatch")
+    if claims.get("exp", 0) < time.time():
+        raise ValueError("ID token expired")
+    if claims.get("nonce") != expected_nonce:
+        raise ValueError("Nonce mismatch")
+    return claims
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_google_token.py -v
+```
+
+Expected: All 10 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/auth/google.py tests/unit/test_google_token.py
+git commit -m "feat(m3): add Google token exchange and ID token validation"
+```
+
+---
+
+## Task 6: User Resolution Logic + Tests
+
+**Files:**
+- Modify: `apps/backend/app/auth/google.py`
+- Create: `apps/backend/tests/unit/test_google_user_resolution.py`
+
+**Step 1: Write the failing tests**
+
+Create `tests/unit/test_google_user_resolution.py`:
+
+```python
+"""Unit tests for Google user resolution logic."""
+
+import pytest
+
+from app.auth.google import PasswordAccountExists, resolve_google_user
+from app.database import Database
+
+
+@pytest.fixture
+async def db():
+    database = Database("sqlite+aiosqlite://")
+    await database.init()
+    yield database
+    await database.close()
+
+
+def _google_claims(
+    sub: str = "google-123",
+    email: str = "user@gmail.com",
+    email_verified: bool = True,
+    name: str = "Test User",
+) -> dict:
+    return {
+        "sub": sub,
+        "email": email,
+        "email_verified": email_verified,
+        "name": name,
+    }
+
+
+class TestResolveGoogleUser:
+    async def test_new_user_created(self, db) -> None:
+        """No existing user or oauth account -> creates both."""
+        claims = _google_claims()
+        user = await resolve_google_user(claims, db)
+        assert user["email"] == "user@gmail.com"
+        assert user["display_name"] == "Test User"
+        # Verify oauth_account was created
+        account = await db.get_oauth_account("google", "google-123")
+        assert account is not None
+        assert account["user_id"] == user["id"]
+
+    async def test_already_linked_returns_existing(self, db) -> None:
+        """OAuth account already exists -> returns linked user."""
+        user = await db.create_user(email="linked@gmail.com")
+        await db.create_oauth_account(
+            user_id=user["id"],
+            provider="google",
+            provider_user_id="g-linked",
+        )
+        claims = _google_claims(sub="g-linked", email="linked@gmail.com")
+        result = await resolve_google_user(claims, db)
+        assert result["id"] == user["id"]
+
+    async def test_autolink_passwordless_account(self, db) -> None:
+        """Email matches a passwordless account -> auto-link."""
+        user = await db.create_user(email="nopass@gmail.com")
+        claims = _google_claims(sub="g-nopass", email="nopass@gmail.com")
+        result = await resolve_google_user(claims, db)
+        assert result["id"] == user["id"]
+        # Verify oauth_account was created
+        account = await db.get_oauth_account("google", "g-nopass")
+        assert account is not None
+        assert account["user_id"] == user["id"]
+
+    async def test_deny_password_account(self, db) -> None:
+        """Email matches a password-bearing account -> raise PasswordAccountExists."""
+        await db.create_user(
+            email="haspass@gmail.com",
+            hashed_password="$argon2id$v=19$m=65536,t=3,p=4$hash",
+        )
+        claims = _google_claims(sub="g-haspass", email="haspass@gmail.com")
+        with pytest.raises(PasswordAccountExists):
+            await resolve_google_user(claims, db)
+
+    async def test_unverified_email_creates_new_account(self, db) -> None:
+        """Unverified Google email -> creates new account, no linking attempt."""
+        await db.create_user(email="existing@gmail.com", hashed_password="h")
+        claims = _google_claims(
+            sub="g-unverified",
+            email="existing@gmail.com",
+            email_verified=False,
+        )
+        user = await resolve_google_user(claims, db)
+        # Should be a different user (new account)
+        existing = await db.get_user_by_email("existing@gmail.com")
+        # The new user was created with the same email -- this tests that
+        # unverified email doesn't trigger the link logic. In practice,
+        # a unique constraint on email would prevent this, so the test
+        # validates the code PATH, not the final DB state.
+        assert user is not None
+
+    async def test_no_email_creates_new_account(self, db) -> None:
+        """Google claims with no email -> creates new account."""
+        claims = {"sub": "g-noemail", "email": "", "email_verified": False, "name": "No Email"}
+        user = await resolve_google_user(claims, db)
+        assert user is not None
+        assert user["display_name"] == "No Email"
+
+    async def test_concurrent_link_handles_integrity_error(self, db) -> None:
+        """If oauth_account was created between check and insert, handle gracefully."""
+        user = await db.create_user(email="race@gmail.com")
+        await db.create_oauth_account(
+            user_id=user["id"],
+            provider="google",
+            provider_user_id="g-race",
+        )
+        # Calling resolve with same sub should find the existing link (path 1)
+        claims = _google_claims(sub="g-race", email="race@gmail.com")
+        result = await resolve_google_user(claims, db)
+        assert result["id"] == user["id"]
+```
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_google_user_resolution.py -v
+```
+
+Expected: FAIL — `resolve_google_user` and `PasswordAccountExists` not defined.
+
+**Step 3: Implement user resolution logic**
+
+Add to `apps/backend/app/auth/google.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# User resolution
+# ---------------------------------------------------------------------------
+
+class PasswordAccountExists(Exception):
+    """Raised when Google email matches an account with a password."""
+    pass
+
+
+async def resolve_google_user(claims: dict, db: "Database") -> dict:
+    """Resolve or create a user from Google ID token claims.
+
+    Four paths:
+    1. OAuth account already linked -> return existing user
+    2a. Verified email matches passwordless account -> auto-link
+    2b. Verified email matches password account -> raise PasswordAccountExists
+    3. No match -> create new user + oauth_account
+    """
+    from app.database import Database  # noqa: F811 — type hint only
+
+    google_sub = claims["sub"]
+    email = claims.get("email", "")
+    email_verified = claims.get("email_verified", False)
+    display_name = claims.get("name")
+
+    # Path 1: Already linked
+    oauth_account = await db.get_oauth_account("google", google_sub)
+    if oauth_account:
+        logger.info("google_auth.returning_existing user_id=%s", oauth_account["user_id"])
+        return await db.get_user_by_id(oauth_account["user_id"])
+
+    # Path 2: Email match (only if verified)
+    if email_verified and email:
+        existing_user = await db.get_user_by_email(email)
+        if existing_user:
+            if existing_user.get("hashed_password"):
+                logger.info("google_auth.denied_password_account email=%s", email)
+                raise PasswordAccountExists()
+            # Auto-link passwordless account
+            await db.create_oauth_account(
+                user_id=existing_user["id"],
+                provider="google",
+                provider_user_id=google_sub,
+                provider_email=email,
+            )
+            logger.info("google_auth.linked_existing user_id=%s", existing_user["id"])
+            return existing_user
+
+    # Path 3: New user
+    user = await db.create_user(email=email, display_name=display_name)
+    await db.create_oauth_account(
+        user_id=user["id"],
+        provider="google",
+        provider_user_id=google_sub,
+        provider_email=email,
+    )
+    logger.info("google_auth.created_new user_id=%s", user["id"])
+    return user
+```
+
+**Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/unit/test_google_user_resolution.py -v
+```
+
+Expected: All 7 tests PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/auth/google.py tests/unit/test_google_user_resolution.py
+git commit -m "feat(m3): add Google user resolution with auto-link and password gate"
+```
+
+---
+
+## Task 7: Google OAuth Router (Start + Callback)
+
+**Files:**
+- Create: `apps/backend/app/routers/google_oauth.py`
+
+**Step 1: Create the router**
+
+Create `apps/backend/app/routers/google_oauth.py`:
+
+```python
+"""Google OAuth 2.0 endpoints: start and callback."""
+
+import hashlib
+import logging
+import secrets
+import time
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+
+from app.auth.constants import (
+    AUTHORIZATION_CODE_EXPIRE_MINUTES,
+    FIRST_PARTY_CLIENT_ID,
+)
+from app.auth.google import (
+    GOOGLE_AUTH_URL,
+    GOOGLE_SCOPES,
+    PasswordAccountExists,
+    exchange_google_code,
+    pack_state,
+    parse_id_token,
+    resolve_google_user,
+    unpack_state,
+    validate_id_token_claims,
+)
+from app.config import settings
+from app.database import db
+from app.routers.oauth import _allowed_redirect_uris
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/oauth/google", tags=["google-oauth"])
+
+
+def _google_callback_uri(request: Request) -> str:
+    """Build the Google callback URI from the request base URL."""
+    return f"{str(request.base_url).rstrip('/')}/api/v1/oauth/google/callback"
+
+
+@router.get("/start")
+async def google_start(
+    request: Request,
+    state: str,
+    code_challenge: str,
+    redirect_uri: str,
+    code_challenge_method: str = "S256",
+) -> RedirectResponse:
+    """Initiate Google OAuth flow.
+
+    Packs the frontend's PKCE params into Google's state parameter
+    with HMAC integrity protection.
+    """
+    if not settings.google_client_id:
+        return RedirectResponse(
+            f"{settings.frontend_origin}/login?error=google_not_configured",
+            status_code=302,
+        )
+
+    if redirect_uri not in _allowed_redirect_uris():
+        return RedirectResponse(
+            f"{settings.frontend_origin}/login?error=invalid_redirect",
+            status_code=302,
+        )
+
+    nonce = secrets.token_urlsafe(32)
+    packed = pack_state(
+        {
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": code_challenge_method,
+            "redirect_uri": redirect_uri,
+            "nonce": nonce,
+            "ts": int(time.time()),
+        },
+        settings.effective_jwt_secret,
+    )
+
+    google_params = urlencode({
+        "client_id": settings.google_client_id,
+        "redirect_uri": _google_callback_uri(request),
+        "response_type": "code",
+        "scope": GOOGLE_SCOPES,
+        "state": packed,
+        "nonce": nonce,
+        "access_type": "online",
+        "prompt": "select_account",
+    })
+
+    return RedirectResponse(
+        f"{GOOGLE_AUTH_URL}?{google_params}",
+        status_code=302,
+    )
+
+
+@router.get("/callback")
+async def google_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+) -> RedirectResponse:
+    """Handle Google's OAuth callback.
+
+    Validates state, exchanges Google's code for tokens, resolves the user,
+    issues our own authorization code, and redirects to the frontend callback.
+    """
+    frontend_login = f"{settings.frontend_origin}/login"
+
+    # Handle Google-side errors
+    if error or not code or not state:
+        logger.warning("Google callback error: %s", error or "missing params")
+        return RedirectResponse(f"{frontend_login}?error=google_failed", status_code=302)
+
+    # Verify HMAC-signed state
+    try:
+        data = unpack_state(state, settings.effective_jwt_secret)
+    except ValueError as e:
+        logger.warning("Google callback invalid state: %s", e)
+        return RedirectResponse(f"{frontend_login}?error=google_failed", status_code=302)
+
+    # Exchange Google code for tokens
+    try:
+        tokens = await exchange_google_code(
+            code=code,
+            redirect_uri=_google_callback_uri(request),
+            client_id=settings.google_client_id,
+            client_secret=settings.google_client_secret,
+        )
+    except ValueError as e:
+        logger.error("Google token exchange failed: %s", e)
+        return RedirectResponse(f"{frontend_login}?error=google_failed", status_code=302)
+
+    # Parse and validate ID token
+    id_token_raw = tokens.get("id_token")
+    if not id_token_raw:
+        logger.error("Google response missing id_token")
+        return RedirectResponse(f"{frontend_login}?error=google_failed", status_code=302)
+
+    try:
+        claims = parse_id_token(id_token_raw)
+        validate_id_token_claims(claims, settings.google_client_id, data["nonce"])
+    except ValueError as e:
+        logger.warning("Google ID token validation failed: %s", e)
+        return RedirectResponse(f"{frontend_login}?error=google_failed", status_code=302)
+
+    # Resolve or create user
+    try:
+        user = await resolve_google_user(claims, db)
+    except PasswordAccountExists:
+        return RedirectResponse(
+            f"{frontend_login}?error=account_exists",
+            status_code=302,
+        )
+
+    # Issue our authorization code (reuses M2's token exchange flow)
+    our_code = secrets.token_urlsafe(32)
+    code_hash = hashlib.sha256(our_code.encode()).hexdigest()
+
+    await db.create_authorization_code(
+        code_hash=code_hash,
+        user_id=user["id"],
+        client_id=FIRST_PARTY_CLIENT_ID,
+        redirect_uri=data["redirect_uri"],
+        code_challenge=data["code_challenge"],
+        scope="openid email profile",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=AUTHORIZATION_CODE_EXPIRE_MINUTES),
+    )
+
+    redirect_url = f"{data['redirect_uri']}?{urlencode({'code': our_code, 'state': data['state']})}"
+    return RedirectResponse(url=redirect_url, status_code=303)
+```
+
+**Step 2: Commit**
+
+```bash
+git add apps/backend/app/routers/google_oauth.py
+git commit -m "feat(m3): add Google OAuth start and callback endpoints"
+```
+
+---
+
+## Task 8: Providers Endpoint + Wiring
+
+**Files:**
+- Modify: `apps/backend/app/routers/auth.py`
+- Modify: `apps/backend/app/routers/__init__.py`
+- Modify: `apps/backend/app/main.py`
+- Modify: `apps/backend/tests/conftest.py`
+
+**Step 1: Add providers endpoint to auth router**
+
+In `apps/backend/app/routers/auth.py`, add after the existing endpoints:
+
+```python
+from app.config import settings  # add if not already imported
+
+@router.get("/providers")
+async def list_providers() -> dict:
+    """Return available authentication providers."""
+    providers = ["credentials"]
+    if settings.google_client_id:
+        providers.append("google")
+    return {"providers": providers}
+```
+
+**Step 2: Export google_oauth_router from __init__.py**
+
+Modify `apps/backend/app/routers/__init__.py`:
+
+```python
+"""API routers."""
+
+from app.routers.auth import router as auth_router
+from app.routers.config import router as config_router
+from app.routers.enrichment import router as enrichment_router
+from app.routers.google_oauth import router as google_oauth_router
+from app.routers.health import router as health_router
+from app.routers.jobs import router as jobs_router
+from app.routers.oauth import router as oauth_router
+from app.routers.resumes import router as resumes_router
+
+__all__ = [
+    "auth_router",
+    "google_oauth_router",
+    "oauth_router",
+    "resumes_router",
+    "jobs_router",
+    "config_router",
+    "health_router",
+    "enrichment_router",
+]
+```
+
+**Step 3: Register google_oauth_router in main.py**
+
+In `apps/backend/app/main.py`:
+
+1. Update the import line:
+```python
+from app.routers import auth_router, config_router, enrichment_router, google_oauth_router, health_router, jobs_router, oauth_router, resumes_router
+```
+
+2. Add the router registration after the oauth_router line:
+```python
+app.include_router(google_oauth_router, prefix="/api/v1")
+```
+
+**Step 4: Update conftest.py for database patching**
+
+In `apps/backend/tests/conftest.py`, add the google_oauth module to the monkeypatching:
+
+```python
+    import app.routers.google_oauth as google_oauth_mod
+
+    for mod in (db_module, auth_deps_mod, auth_mod, oauth_mod, google_oauth_mod, resumes_mod, jobs_mod, health_mod, config_mod, enrichment_mod, main_mod):
+```
+
+**Step 5: Verify everything still starts and existing tests pass**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/ -v
+```
+
+Expected: All existing tests PASS.
+
+**Step 6: Commit**
+
+```bash
+git add apps/backend/app/routers/auth.py apps/backend/app/routers/__init__.py apps/backend/app/main.py apps/backend/tests/conftest.py
+git commit -m "feat(m3): wire up Google OAuth router and providers endpoint"
+```
+
+---
+
+## Task 9: Integration Tests
+
+**Files:**
+- Create: `apps/backend/tests/integration/test_google_oauth_api.py`
+
+**Step 1: Write integration tests**
+
+Create `tests/integration/test_google_oauth_api.py`:
+
+```python
+"""Integration tests for Google OAuth flow."""
+
+import base64
+import json
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.auth.google import pack_state
+
+
+def _make_id_token(claims: dict) -> str:
+    """Build a fake JWT with the given claims."""
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).decode().rstrip("=")
+    payload = base64.urlsafe_b64encode(json.dumps(claims).encode()).decode().rstrip("=")
+    sig = base64.urlsafe_b64encode(b"sig").decode().rstrip("=")
+    return f"{header}.{payload}.{sig}"
+
+
+class TestProvidersEndpoint:
+    async def test_providers_credentials_only(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "")
+        resp = await client.get("/api/v1/auth/providers")
+        assert resp.status_code == 200
+        assert resp.json() == {"providers": ["credentials"]}
+
+    async def test_providers_with_google(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-google-id")
+        resp = await client.get("/api/v1/auth/providers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "google" in data["providers"]
+        assert "credentials" in data["providers"]
+
+
+class TestGoogleStart:
+    async def test_redirects_to_google(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-google-id")
+        monkeypatch.setattr("app.config.settings.google_client_secret", "test-secret")
+        resp = await client.get(
+            "/api/v1/oauth/google/start",
+            params={
+                "state": "test-state",
+                "code_challenge": "test-challenge",
+                "redirect_uri": "http://localhost:3000/callback",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert "accounts.google.com" in location
+        assert "test-google-id" in location
+
+    async def test_google_not_configured(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "")
+        resp = await client.get(
+            "/api/v1/oauth/google/start",
+            params={
+                "state": "s",
+                "code_challenge": "c",
+                "redirect_uri": "http://localhost:3000/callback",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "google_not_configured" in resp.headers["location"]
+
+    async def test_invalid_redirect_uri(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-id")
+        resp = await client.get(
+            "/api/v1/oauth/google/start",
+            params={
+                "state": "s",
+                "code_challenge": "c",
+                "redirect_uri": "https://evil.com/callback",
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "invalid_redirect" in resp.headers["location"]
+
+    async def test_missing_params(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-id")
+        resp = await client.get("/api/v1/oauth/google/start", follow_redirects=False)
+        assert resp.status_code == 422
+
+
+class TestGoogleCallback:
+    def _setup_google_mock(self, monkeypatch, nonce: str, email: str = "google@gmail.com",
+                           email_verified: bool = True, sub: str = "g-sub-123"):
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-google-id")
+        monkeypatch.setattr("app.config.settings.google_client_secret", "test-secret")
+
+        claims = {
+            "iss": "https://accounts.google.com",
+            "aud": "test-google-id",
+            "exp": int(time.time()) + 300,
+            "nonce": nonce,
+            "sub": sub,
+            "email": email,
+            "email_verified": email_verified,
+            "name": "Google User",
+        }
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "google-at",
+            "id_token": _make_id_token(claims),
+            "token_type": "Bearer",
+        }
+
+        mock_client_instance = AsyncMock()
+        mock_client_instance.post.return_value = mock_response
+        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
+        mock_client_instance.__aexit__ = AsyncMock(return_value=False)
+
+        return mock_client_instance
+
+    async def test_full_callback_new_user(self, client, monkeypatch) -> None:
+        """Full Google callback: new user created, redirects with our auth code."""
+        nonce = "test-nonce"
+        mock_http = self._setup_google_mock(monkeypatch, nonce)
+
+        packed = pack_state(
+            {
+                "state": "frontend-state",
+                "code_challenge": "challenge123",
+                "code_challenge_method": "S256",
+                "redirect_uri": "http://localhost:3000/callback",
+                "nonce": nonce,
+                "ts": int(time.time()),
+            },
+            "test-secret-for-tests",
+        )
+
+        with patch("app.routers.google_oauth.exchange_google_code") as mock_exchange:
+            claims = {
+                "iss": "https://accounts.google.com",
+                "aud": "test-google-id",
+                "exp": int(time.time()) + 300,
+                "nonce": nonce,
+                "sub": "g-new-user",
+                "email": "new@gmail.com",
+                "email_verified": True,
+                "name": "New Google User",
+            }
+            mock_exchange.return_value = {
+                "access_token": "at",
+                "id_token": _make_id_token(claims),
+            }
+
+            resp = await client.get(
+                "/api/v1/oauth/google/callback",
+                params={"code": "google-code", "state": packed},
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 303
+        location = resp.headers["location"]
+        assert "localhost:3000/callback" in location
+        assert "code=" in location
+        assert "state=frontend-state" in location
+
+    async def test_callback_google_error(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-id")
+        resp = await client.get(
+            "/api/v1/oauth/google/callback",
+            params={"error": "access_denied"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "google_failed" in resp.headers["location"]
+
+    async def test_callback_invalid_state(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-id")
+        resp = await client.get(
+            "/api/v1/oauth/google/callback",
+            params={"code": "c", "state": "tampered.state"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "google_failed" in resp.headers["location"]
+
+    async def test_callback_expired_state(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-id")
+        packed = pack_state(
+            {"state": "s", "nonce": "n", "ts": int(time.time()) - 700,
+             "redirect_uri": "http://localhost:3000/callback",
+             "code_challenge": "c", "code_challenge_method": "S256"},
+            "test-secret-for-tests",
+        )
+        resp = await client.get(
+            "/api/v1/oauth/google/callback",
+            params={"code": "c", "state": packed},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "google_failed" in resp.headers["location"]
+
+    async def test_callback_password_account_denied(self, client, test_db, monkeypatch) -> None:
+        """Google email matches password account -> redirect with account_exists."""
+        from app.auth.password import hash_password
+
+        await test_db.create_user(
+            email="existing@gmail.com",
+            hashed_password=hash_password("password123"),
+        )
+
+        nonce = "nonce-pw"
+        packed = pack_state(
+            {
+                "state": "s", "code_challenge": "c", "code_challenge_method": "S256",
+                "redirect_uri": "http://localhost:3000/callback",
+                "nonce": nonce, "ts": int(time.time()),
+            },
+            "test-secret-for-tests",
+        )
+
+        claims = {
+            "iss": "https://accounts.google.com",
+            "aud": "test-google-id",
+            "exp": int(time.time()) + 300,
+            "nonce": nonce,
+            "sub": "g-existing",
+            "email": "existing@gmail.com",
+            "email_verified": True,
+            "name": "Existing User",
+        }
+
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-google-id")
+        monkeypatch.setattr("app.config.settings.google_client_secret", "test-secret")
+
+        with patch("app.routers.google_oauth.exchange_google_code") as mock_exchange:
+            mock_exchange.return_value = {"id_token": _make_id_token(claims)}
+            resp = await client.get(
+                "/api/v1/oauth/google/callback",
+                params={"code": "c", "state": packed},
+                follow_redirects=False,
+            )
+
+        assert resp.status_code == 302
+        assert "account_exists" in resp.headers["location"]
+
+    async def test_callback_missing_code(self, client, monkeypatch) -> None:
+        monkeypatch.setattr("app.config.settings.google_client_id", "test-id")
+        resp = await client.get(
+            "/api/v1/oauth/google/callback",
+            params={"state": "s"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert "google_failed" in resp.headers["location"]
+```
+
+**Step 2: Run integration tests**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/integration/test_google_oauth_api.py -v
+```
+
+Expected: All tests PASS.
+
+**Step 3: Run full test suite to verify no regressions**
+
+```bash
+cd apps/backend && .venv/bin/python -m pytest tests/ -v
+```
+
+Expected: All tests PASS.
+
+**Step 4: Commit**
+
+```bash
+git add tests/integration/test_google_oauth_api.py
+git commit -m "test(m3): add Google OAuth integration tests"
+```
+
+---
+
+## Task 10: Frontend — Google Sign-In Button + i18n
+
+**Files:**
+- Modify: `apps/frontend/lib/auth/oauth.ts`
+- Modify: `apps/frontend/app/(auth)/login/page.tsx`
+- Modify: `apps/frontend/components/auth/login-form.tsx`
+- Modify: `apps/frontend/messages/en.json`
+- Modify: `apps/frontend/messages/es.json`
+- Modify: `apps/frontend/messages/ja.json`
+- Modify: `apps/frontend/messages/pt-BR.json`
+- Modify: `apps/frontend/messages/zh.json`
+
+**Step 1: Add startGoogleLogin to oauth.ts**
+
+Add to `apps/frontend/lib/auth/oauth.ts`, after the existing `startLogin` function:
+
+```typescript
+export async function startGoogleLogin(): Promise<void> {
+  const { codeVerifier, codeChallenge } = await generatePKCE();
+  const state = crypto.randomUUID();
+  sessionStorage.setItem(VERIFIER_KEY, codeVerifier);
+  sessionStorage.setItem(STATE_KEY, state);
+
+  const params = new URLSearchParams({
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    redirect_uri: getRedirectUri(),
+  });
+  window.location.href = `${API_BASE}/oauth/google/start?${params}`;
+}
+```
+
+Also add the `API_BASE` import at the top if not already present:
+```typescript
+import { apiFetch, API_BASE } from '@/lib/api/client';
+```
+
+**Step 2: Update login page to show Google button and handle errors**
+
+Replace `apps/frontend/app/(auth)/login/page.tsx` with:
+
+```tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
+import { LoginForm } from '@/components/auth/login-form';
+import { startLogin, startGoogleLogin } from '@/lib/auth/oauth';
+import { apiFetch } from '@/lib/api/client';
+import { useTranslations } from '@/lib/i18n/translations';
+
+function LoginContent() {
+  const { t } = useTranslations();
+  const params = useSearchParams();
+  const [pkce, setPkce] = useState<{ codeChallenge: string; state: string } | null>(null);
+  const [initFailed, setInitFailed] = useState(false);
+  const [providers, setProviders] = useState<string[]>(['credentials']);
+  const [googleLoading, setGoogleLoading] = useState(false);
+
+  const errorParam = params.get('error');
+  const errorMessage = errorParam === 'account_exists'
+    ? t('auth.accountExistsPassword')
+    : errorParam === 'google_failed'
+      ? t('auth.googleFailed')
+      : null;
+
+  useEffect(() => {
+    startLogin()
+      .then(({ codeChallenge, state }) => setPkce({ codeChallenge, state }))
+      .catch(() => setInitFailed(true));
+
+    apiFetch('/auth/providers')
+      .then((r) => r.json())
+      .then((d) => setProviders(d.providers ?? ['credentials']))
+      .catch(() => {});
+  }, []);
+
+  const handleGoogleLogin = () => {
+    setGoogleLoading(true);
+    startGoogleLogin();
+  };
+
+  if (initFailed) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#F0F0E8]">
+        <div className="w-full max-w-sm border border-[#DC2626] bg-white p-8 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+          <p className="font-sans text-sm text-[#DC2626]">{t('auth.pkceError')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!pkce) return null;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#F0F0E8]">
+      <div className="w-full max-w-sm border border-black bg-white p-8 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+        <h1 className="mb-6 font-serif text-2xl font-bold">{t('auth.signIn')}</h1>
+
+        {errorMessage && (
+          <div className="mb-4 border border-[#DC2626] bg-red-50 p-3 font-sans text-sm text-[#DC2626]">
+            {errorMessage}
+          </div>
+        )}
+
+        {providers.includes('google') && (
+          <>
+            <button
+              type="button"
+              onClick={handleGoogleLogin}
+              disabled={googleLoading}
+              className="flex w-full items-center justify-center gap-2 rounded-none border border-black bg-white px-4 py-2 font-sans text-sm hover:bg-gray-50 disabled:opacity-50"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4" aria-hidden="true">
+                <path
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                  fill="#4285F4"
+                />
+                <path
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                  fill="#34A853"
+                />
+                <path
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                  fill="#FBBC05"
+                />
+                <path
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                  fill="#EA4335"
+                />
+              </svg>
+              {googleLoading ? t('auth.signingIn') : t('auth.signInWithGoogle')}
+            </button>
+            <div className="relative my-4">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-gray-300" />
+              </div>
+              <div className="relative flex justify-center">
+                <span className="bg-white px-2 font-mono text-xs uppercase tracking-wider text-gray-500">
+                  {t('auth.orContinueWith')}
+                </span>
+              </div>
+            </div>
+          </>
+        )}
+
+        <LoginForm codeChallenge={pkce.codeChallenge} state={pkce.state} />
+      </div>
+    </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginContent />
+    </Suspense>
+  );
+}
+```
+
+**Step 3: Add i18n strings to all locales**
+
+Add these keys to the `auth` section of each locale file:
+
+**en.json:**
+```json
+"signInWithGoogle": "Sign in with Google",
+"orContinueWith": "or continue with",
+"accountExistsPassword": "An account with this email already exists. Please sign in with your password.",
+"googleFailed": "Google sign-in failed. Please try again."
+```
+
+**es.json:**
+```json
+"signInWithGoogle": "Iniciar sesion con Google",
+"orContinueWith": "o continuar con",
+"accountExistsPassword": "Ya existe una cuenta con este correo electronico. Por favor, inicia sesion con tu contrasena.",
+"googleFailed": "Error al iniciar sesion con Google. Por favor, intentalo de nuevo."
+```
+
+**ja.json:**
+```json
+"signInWithGoogle": "Google でサインイン",
+"orContinueWith": "または以下で続行",
+"accountExistsPassword": "このメールアドレスのアカウントは既に存在します。パスワードでサインインしてください。",
+"googleFailed": "Google サインインに失敗しました。もう一度お試しください。"
+```
+
+**pt-BR.json:**
+```json
+"signInWithGoogle": "Entrar com Google",
+"orContinueWith": "ou continue com",
+"accountExistsPassword": "Uma conta com este e-mail ja existe. Por favor, entre com sua senha.",
+"googleFailed": "Falha ao entrar com Google. Por favor, tente novamente."
+```
+
+**zh.json:**
+```json
+"signInWithGoogle": "使用 Google 登录",
+"orContinueWith": "或继续使用",
+"accountExistsPassword": "此电子邮件已存在账户。请使用密码登录。",
+"googleFailed": "Google 登录失败。请重试。"
+```
+
+**Step 4: Run frontend lint and format**
+
+```bash
+cd apps/frontend && npm run lint && npm run format
+```
+
+**Step 5: Build frontend to verify no compilation errors**
+
+```bash
+cd apps/frontend && npm run build
+```
+
+**Step 6: Commit**
+
+```bash
+git add apps/frontend/lib/auth/oauth.ts apps/frontend/app/\(auth\)/login/page.tsx apps/frontend/messages/
+git commit -m "feat(m3): add Google sign-in button with i18n and provider detection"
+```
+
+---
+
+## Task Summary
+
+| Task | Description | Tests |
+|------|-------------|-------|
+| 1 | OAuthAccount model + Alembic migration | — |
+| 2 | OAuthAccount database CRUD | 6 unit tests |
+| 3 | Config additions + optional password | Existing tests verify no regression |
+| 4 | State packing/unpacking | 7 unit tests |
+| 5 | Google token exchange + ID token validation | 10 unit tests |
+| 6 | User resolution logic | 7 unit tests |
+| 7 | Google OAuth router (start + callback) | — |
+| 8 | Providers endpoint + wiring | — |
+| 9 | Integration tests | 10 integration tests |
+| 10 | Frontend: Google button + i18n | Lint + build verification |
+
+**Total: 40 tests (30 unit + 10 integration)**
+
+---
+
+## Security Checklist
+
+Before merging, verify:
+- [ ] HMAC state passes all tamper/expiry tests
+- [ ] ID token validates iss, aud, exp, nonce
+- [ ] Password accounts cannot be auto-linked
+- [ ] `(provider, provider_user_id)` unique constraint exists
+- [ ] Google errors redirect with generic message (no detail leakage)
+- [ ] `GOOGLE_CLIENT_SECRET` never appears in logs or responses
+- [ ] `redirect_uri` validated against allowlist on `/google/start`
+- [ ] All 5 locales have Google auth strings

--- a/docs/plans/2026-04-03-m4-multi-user-data-isolation-design.md
+++ b/docs/plans/2026-04-03-m4-multi-user-data-isolation-design.md
@@ -1,0 +1,133 @@
+# M4: Multi-User Data Isolation — Design Document
+
+**Goal:** Add authentication and user-scoped data isolation to all data endpoints so each user sees only their own resumes, jobs, and tailoring results.
+
+**Architecture:** Bottom-up approach — change database method signatures to require `user_id`, then update routers to inject it via `get_current_user`. The DB layer enforces the invariant; application code cannot skip it.
+
+**Tech Stack:** FastAPI dependencies, SQLAlchemy queries, Alembic migration, existing JWT auth from M2.
+
+---
+
+## Understanding Summary
+
+- **What:** Add authentication and user-scoped data isolation to all data endpoints (resumes, jobs, enrichment, status)
+- **Why:** Resume Matcher is transitioning from single-user local app to multi-user server — user data must not leak across accounts
+- **Who:** All authenticated users — every user sees only their own resumes, jobs, and tailoring results
+- **Key constraints:** No production data to migrate; frontend already has auth from M2; auth infrastructure (`get_current_user`) exists but is unused in data routers
+- **Non-goals:** Config endpoints (deferred), admin roles (deferred), row-level security / tenant sharding (unnecessary at current scale)
+
+## Assumptions
+
+1. No production data exists — destructive migration (NOT NULL) is safe
+2. Frontend already sends Bearer tokens (M2) — just needs to include them on all API calls
+3. `get_current_user` dependency works correctly (tested in M2)
+4. All existing integration tests will break and need auth fixtures — this is expected
+5. `get_optional_user` will not be used for data endpoints — strict auth only
+
+---
+
+## Decision Log
+
+| # | Decision | Alternatives | Rationale |
+|---|----------|-------------|-----------|
+| 1 | Config endpoints deferred to later milestone | Admin-only now, remove entirely | Keeps M4 focused on data isolation |
+| 2 | Make user_id NOT NULL on Resume, Job, Improvement | Keep nullable, two-phase migration | No prod data; DB enforces invariant |
+| 3 | Per-user master resume via partial unique index on `(user_id) WHERE is_master = TRUE` | FK on User model, remove concept entirely | Minimal change, strong DB-level guarantee |
+| 4 | Always 404 for cross-user access | 403, mixed 404/403 | Prevents enumeration attacks, simpler single query |
+| 5 | `/status` scoped to authenticated user | Remove it, keep public/anonymous | Natural multi-user evolution of dashboard summary |
+| 6 | Enrichment endpoints require auth + independent ownership check | Rely on downstream DB scoping | Defense in depth — every entry point validates |
+| 7 | Bottom-up approach (DB layer first, then routers) | Top-down (routers first), middleware | DB method signatures enforce invariant; callers cannot skip |
+
+---
+
+## Design
+
+### 1. Alembic Migration
+
+Single migration that:
+1. Deletes all rows from `resumes`, `jobs`, `improvements` (no production data)
+2. Makes `user_id` NOT NULL on all three tables
+3. Adds partial unique index: `CREATE UNIQUE INDEX ix_resumes_user_master ON resumes (user_id) WHERE is_master = TRUE`
+
+### 2. Database Layer Changes
+
+Every CRUD method gains a `user_id: str` parameter. Every query adds `& (Model.user_id == user_id)` to the WHERE clause.
+
+| Method | Current Signature | New Signature |
+|--------|-------------------|---------------|
+| `create_resume(...)` | No user_id | `create_resume(..., user_id: str)` |
+| `create_resume_atomic_master(...)` | No user_id | `create_resume_atomic_master(..., user_id: str)` |
+| `get_resume(resume_id)` | By ID only | `get_resume(resume_id, user_id: str)` |
+| `get_master_resume()` | Global singleton | `get_master_resume(user_id: str)` |
+| `update_resume(resume_id, updates)` | By ID only | `update_resume(resume_id, user_id: str, updates)` |
+| `delete_resume(resume_id)` | By ID only | `delete_resume(resume_id, user_id: str)` |
+| `list_resumes()` | All resumes | `list_resumes(user_id: str)` |
+| `set_master_resume(resume_id)` | Global | `set_master_resume(resume_id, user_id: str)` |
+| `create_job(content, resume_id)` | No user_id | `create_job(content, resume_id, user_id: str)` |
+| `get_job(job_id)` | By ID only | `get_job(job_id, user_id: str)` |
+| `update_job(job_id, updates)` | By ID only | `update_job(job_id, user_id: str, updates)` |
+| `create_improvement(...)` | No user_id | `create_improvement(..., user_id: str)` |
+| `get_improvement_by_tailored_resume(id)` | By ID only | `get_improvement_by_tailored_resume(id, user_id: str)` |
+| `get_stats()` | Global | `get_stats(user_id: str)` |
+
+Methods that find no matching row return `None`; routers raise 404.
+
+### 3. Router Layer Changes
+
+25 endpoints gain `Depends(get_current_user)`:
+
+| Router | Endpoints | Count |
+|--------|-----------|-------|
+| `resumes.py` | All 17 endpoints | 17 |
+| `jobs.py` | Both endpoints | 2 |
+| `enrichment.py` | All 5 endpoints | 5 |
+| `health.py` | `get_status` only | 1 |
+| **Total** | | **25** |
+
+Endpoints that stay unauthenticated:
+- `GET /health` — public health check
+- `GET /auth/providers` — public feature detection
+- `POST /auth/register` — public registration
+- `GET /auth/me` — already has auth
+- All `/oauth/*` endpoints — handle their own auth flow
+- All `/config/*` endpoints — deferred (Decision 1)
+
+Service functions called by routers (improve_resume, generate_cover_letter, etc.) also receive `user_id` and pass it to all DB calls.
+
+### 4. Frontend Changes
+
+Switch data API calls from `apiFetch` to `authFetch` (which injects Bearer token):
+
+| File | Change |
+|------|--------|
+| `lib/api/resume.ts` | All ~15 calls switch to `authFetch` |
+| `lib/api/enrichment.ts` | All ~5 calls switch to `authFetch` |
+| `lib/api/config.ts` | Only `/status` call switches; config calls stay unauthenticated (deferred) |
+
+Calls that stay unauthenticated (correctly):
+- `oauth.ts` — token exchange, refresh, revoke (cookie-based)
+- `context.tsx` — `/auth/me` (manually adds Bearer)
+- `login-form.tsx`, `register-form.tsx`, `login/page.tsx` — auth flow endpoints
+
+### 5. Testing Strategy
+
+**Fixture changes:**
+- `auth_token` fixture: creates user, returns valid JWT
+- `second_user_token` fixture: creates second user for isolation tests
+- All integration tests include `Authorization: Bearer {token}` header
+- All DB unit tests pass `user_id` to CRUD methods
+
+**New test categories:**
+1. **Isolation tests** — User A creates resume, User B gets 404
+2. **Ownership tests** — Endpoints return only authenticated user's data
+3. **401 tests** — Data endpoints return 401 without Bearer token
+4. **Master resume scoping** — User A's master independent of User B's
+5. **Migration test** — NOT NULL constraint and partial unique index verified
+
+### 6. Error Handling & Edge Cases
+
+- **Expired token:** Backend returns 401, frontend refreshes via existing M2 mechanism
+- **User deleted while session active:** `get_current_user` returns 401
+- **Concurrent master set:** Partial unique index prevents two masters; `set_master_resume` unsets existing first
+- **Upload without auth:** Returns 401 before file processing
+- **Service function chains:** All calls within a service use same `user_id`

--- a/docs/plans/2026-04-03-m4-multi-user-data-isolation-plan.md
+++ b/docs/plans/2026-04-03-m4-multi-user-data-isolation-plan.md
@@ -1,0 +1,1285 @@
+# M4: Multi-User Data Isolation — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add authentication and user-scoped data isolation to all data endpoints so each user sees only their own resumes, jobs, and tailoring results.
+
+**Architecture:** Bottom-up — modify database method signatures to require `user_id`, then update routers to inject it from `get_current_user`. The DB layer enforces the invariant.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 async, Alembic, JWT auth (from M2), Next.js `authFetch`.
+
+**Design doc:** `docs/plans/2026-04-03-m4-multi-user-data-isolation-design.md`
+
+---
+
+### Task 1: Alembic Migration & Model Changes
+
+**Files:**
+- Modify: `apps/backend/app/models.py:33,53,68`
+- Create: `apps/backend/alembic/versions/xxxx_make_user_id_not_null.py`
+- Test: `apps/backend/tests/unit/test_models.py` (existing — verify schema)
+
+**Step 1: Update models — make user_id NOT NULL**
+
+In `apps/backend/app/models.py`, change the three nullable user_id columns:
+
+```python
+# Resume model (line 33) — change from:
+user_id: Mapped[str | None] = mapped_column(ForeignKey("users.id"), index=True)
+# to:
+user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
+
+# Job model (line 53) — same change:
+user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
+
+# Improvement model (line 68) — same change:
+user_id: Mapped[str] = mapped_column(ForeignKey("users.id"), index=True)
+```
+
+Also update the Resume relationship from:
+```python
+user: Mapped["User | None"] = relationship(back_populates="resumes")
+```
+to:
+```python
+user: Mapped["User"] = relationship(back_populates="resumes")
+```
+
+**Step 2: Create Alembic migration**
+
+Run:
+```bash
+cd apps/backend && uv run alembic revision --autogenerate -m "make_user_id_not_null_add_master_index"
+```
+
+Then edit the generated migration to add the destructive cleanup and partial unique index. The migration should look like:
+
+```python
+"""make_user_id_not_null_add_master_index
+
+Revision ID: <auto>
+Revises: 42511b93573f
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '<auto>'
+down_revision: Union[str, None] = '42511b93573f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Delete orphaned data (no production data exists)
+    op.execute("DELETE FROM improvements")
+    op.execute("DELETE FROM jobs")
+    op.execute("DELETE FROM resumes")
+
+    # Make user_id NOT NULL on all three tables
+    with op.batch_alter_table("resumes") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=False)
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=False)
+    with op.batch_alter_table("improvements") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=False)
+
+    # Per-user master resume: at most one master per user
+    op.create_index(
+        "ix_resumes_user_master",
+        "resumes",
+        ["user_id"],
+        unique=True,
+        postgresql_where=sa.text("is_master = true"),
+        sqlite_where=sa.text("is_master = 1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_resumes_user_master", table_name="resumes")
+    with op.batch_alter_table("improvements") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=True)
+    with op.batch_alter_table("jobs") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=True)
+    with op.batch_alter_table("resumes") as batch_op:
+        batch_op.alter_column("user_id", existing_type=sa.String(36), nullable=True)
+```
+
+**Step 3: Verify model tests still pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/test_models.py -v`
+Expected: PASS (tests create models via ORM, may need user_id added)
+
+**Step 4: Commit**
+
+```bash
+git add apps/backend/app/models.py apps/backend/alembic/versions/
+git commit -m "feat(m4): make user_id NOT NULL, add per-user master index"
+```
+
+---
+
+### Task 2: Database Layer — Resume Operations with user_id
+
+**Files:**
+- Modify: `apps/backend/app/database.py:141-242`
+- Test: `apps/backend/tests/unit/test_database_user_scoping.py` (create)
+
+**Step 1: Write failing tests for user-scoped resume operations**
+
+Create `apps/backend/tests/unit/test_database_user_scoping.py`:
+
+```python
+"""Tests for user-scoped database operations."""
+
+import pytest
+
+from app.database import Database
+
+
+@pytest.fixture
+async def db():
+    database = Database("sqlite+aiosqlite://")
+    await database.init()
+    yield database
+    await database.close()
+
+
+@pytest.fixture
+async def user_a(db):
+    return await db.create_user(email="a@test.com", hashed_password="hash_a")
+
+
+@pytest.fixture
+async def user_b(db):
+    return await db.create_user(email="b@test.com", hashed_password="hash_b")
+
+
+# -- Resume scoping --
+
+class TestResumeScoping:
+    async def test_create_resume_requires_user_id(self, db, user_a):
+        resume = await db.create_resume(content="# Resume", user_id=user_a["id"])
+        assert resume["resume_id"]
+
+    async def test_get_resume_scoped_to_user(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# A", user_id=user_a["id"])
+        # Owner can see it
+        assert await db.get_resume(resume["resume_id"], user_id=user_a["id"]) is not None
+        # Other user cannot
+        assert await db.get_resume(resume["resume_id"], user_id=user_b["id"]) is None
+
+    async def test_list_resumes_scoped_to_user(self, db, user_a, user_b):
+        await db.create_resume(content="# A", user_id=user_a["id"])
+        await db.create_resume(content="# B", user_id=user_b["id"])
+        a_resumes = await db.list_resumes(user_id=user_a["id"])
+        assert len(a_resumes) == 1
+
+    async def test_update_resume_scoped_to_user(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# A", user_id=user_a["id"])
+        # Owner can update
+        updated = await db.update_resume(resume["resume_id"], user_id=user_a["id"], updates={"content": "# Updated"})
+        assert updated["content"] == "# Updated"
+        # Other user gets ValueError (not found)
+        with pytest.raises(ValueError):
+            await db.update_resume(resume["resume_id"], user_id=user_b["id"], updates={"content": "# Hack"})
+
+    async def test_delete_resume_scoped_to_user(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# A", user_id=user_a["id"])
+        # Other user cannot delete
+        assert await db.delete_resume(resume["resume_id"], user_id=user_b["id"]) is False
+        # Owner can
+        assert await db.delete_resume(resume["resume_id"], user_id=user_a["id"]) is True
+
+    async def test_get_master_resume_scoped(self, db, user_a, user_b):
+        await db.create_resume(content="# A Master", user_id=user_a["id"], is_master=True)
+        await db.create_resume(content="# B Master", user_id=user_b["id"], is_master=True)
+        a_master = await db.get_master_resume(user_id=user_a["id"])
+        assert "A Master" in a_master["content"]
+        b_master = await db.get_master_resume(user_id=user_b["id"])
+        assert "B Master" in b_master["content"]
+
+    async def test_set_master_resume_scoped(self, db, user_a, user_b):
+        r1 = await db.create_resume(content="# A1", user_id=user_a["id"], is_master=True)
+        r2 = await db.create_resume(content="# A2", user_id=user_a["id"])
+        rb = await db.create_resume(content="# B1", user_id=user_b["id"], is_master=True)
+        # Set r2 as master for user A — should not affect user B
+        assert await db.set_master_resume(r2["resume_id"], user_id=user_a["id"]) is True
+        b_master = await db.get_master_resume(user_id=user_b["id"])
+        assert b_master["resume_id"] == rb["resume_id"]
+        assert b_master["is_master"] is True
+
+    async def test_create_resume_atomic_master_scoped(self, db, user_a, user_b):
+        # User A gets first master
+        r_a = await db.create_resume_atomic_master(content="# A", user_id=user_a["id"])
+        assert r_a["is_master"] is True
+        # User B also gets their own master (independent)
+        r_b = await db.create_resume_atomic_master(content="# B", user_id=user_b["id"])
+        assert r_b["is_master"] is True
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/test_database_user_scoping.py -v`
+Expected: FAIL — `create_resume()` doesn't accept `user_id` parameter yet
+
+**Step 3: Implement user-scoped resume operations**
+
+Modify `apps/backend/app/database.py`:
+
+**`create_resume`** — add `user_id: str` parameter:
+```python
+async def create_resume(
+    self,
+    content: str,
+    user_id: str,
+    content_type: str = "md",
+    filename: str | None = None,
+    is_master: bool = False,
+    parent_id: str | None = None,
+    processed_data: dict[str, Any] | None = None,
+    processing_status: str = "pending",
+    cover_letter: str | None = None,
+    outreach_message: str | None = None,
+    title: str | None = None,
+    original_markdown: str | None = None,
+) -> dict[str, Any]:
+    resume = Resume(
+        resume_id=str(uuid4()),
+        user_id=user_id,
+        content=content,
+        content_type=content_type,
+        filename=filename,
+        is_master=is_master,
+        parent_id=parent_id,
+        processed_data=processed_data,
+        processing_status=processing_status,
+        cover_letter=cover_letter,
+        outreach_message=outreach_message,
+        title=title,
+        original_markdown=original_markdown,
+    )
+    async with self._session() as session:
+        session.add(resume)
+        await session.commit()
+        await session.refresh(resume)
+        return self._resume_to_dict(resume)
+```
+
+**`create_resume_atomic_master`** — add `user_id: str` parameter, scope to user:
+```python
+async def create_resume_atomic_master(
+    self,
+    content: str,
+    user_id: str,
+    content_type: str = "md",
+    filename: str | None = None,
+    processed_data: dict[str, Any] | None = None,
+    processing_status: str = "pending",
+    cover_letter: str | None = None,
+    outreach_message: str | None = None,
+    original_markdown: str | None = None,
+) -> dict[str, Any]:
+    async with self._master_resume_lock:
+        current_master = await self.get_master_resume(user_id)
+        is_master = current_master is None
+        if current_master and current_master.get("processing_status") in ("failed", "processing"):
+            await self.update_resume(current_master["resume_id"], user_id, {"is_master": False})
+            is_master = True
+        return await self.create_resume(
+            content=content, user_id=user_id, content_type=content_type,
+            filename=filename, is_master=is_master, processed_data=processed_data,
+            processing_status=processing_status, cover_letter=cover_letter,
+            outreach_message=outreach_message, original_markdown=original_markdown,
+        )
+```
+
+**`get_resume`** — add `user_id: str` parameter:
+```python
+async def get_resume(self, resume_id: str, user_id: str) -> dict[str, Any] | None:
+    async with self._session() as session:
+        result = await session.execute(
+            select(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id)
+        )
+        row = result.scalar_one_or_none()
+        return self._resume_to_dict(row) if row else None
+```
+
+**`get_master_resume`** — add `user_id: str` parameter:
+```python
+async def get_master_resume(self, user_id: str) -> dict[str, Any] | None:
+    async with self._session() as session:
+        result = await session.execute(
+            select(Resume).where(Resume.is_master == True, Resume.user_id == user_id)
+        )
+        row = result.scalar_one_or_none()
+        return self._resume_to_dict(row) if row else None
+```
+
+**`update_resume`** — add `user_id: str` parameter:
+```python
+async def update_resume(self, resume_id: str, user_id: str, updates: dict[str, Any]) -> dict[str, Any]:
+    updates["updated_at"] = datetime.now(timezone.utc)
+    async with self._session() as session:
+        result = await session.execute(
+            update(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id).values(**updates)
+        )
+        if result.rowcount == 0:
+            raise ValueError(f"Resume not found: {resume_id}")
+        await session.commit()
+    return await self.get_resume(resume_id, user_id)
+```
+
+**`delete_resume`** — add `user_id: str` parameter:
+```python
+async def delete_resume(self, resume_id: str, user_id: str) -> bool:
+    async with self._session() as session:
+        result = await session.execute(
+            delete(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id)
+        )
+        await session.commit()
+        return result.rowcount > 0
+```
+
+**`list_resumes`** — add `user_id: str` parameter:
+```python
+async def list_resumes(self, user_id: str) -> list[dict[str, Any]]:
+    async with self._session() as session:
+        result = await session.execute(select(Resume).where(Resume.user_id == user_id))
+        return [self._resume_to_dict(r) for r in result.scalars().all()]
+```
+
+**`set_master_resume`** — add `user_id: str` parameter, scope unset to user only:
+```python
+async def set_master_resume(self, resume_id: str, user_id: str) -> bool:
+    async with self._session() as session:
+        target = await session.execute(
+            select(Resume).where(Resume.resume_id == resume_id, Resume.user_id == user_id)
+        )
+        if not target.scalar_one_or_none():
+            logger.warning("Cannot set master: resume %s not found for user", resume_id)
+            return False
+        await session.execute(
+            update(Resume).where(Resume.is_master == True, Resume.user_id == user_id).values(is_master=False)
+        )
+        await session.execute(
+            update(Resume).where(Resume.resume_id == resume_id).values(is_master=True)
+        )
+        await session.commit()
+        return True
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `cd apps/backend && uv run pytest tests/unit/test_database_user_scoping.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/database.py apps/backend/tests/unit/test_database_user_scoping.py
+git commit -m "feat(m4): add user_id scoping to resume database operations"
+```
+
+---
+
+### Task 3: Database Layer — Job, Improvement & Stats with user_id
+
+**Files:**
+- Modify: `apps/backend/app/database.py:246-498`
+- Test: `apps/backend/tests/unit/test_database_user_scoping.py` (append)
+
+**Step 1: Write failing tests for job/improvement/stats scoping**
+
+Append to `apps/backend/tests/unit/test_database_user_scoping.py`:
+
+```python
+# -- Job scoping --
+
+class TestJobScoping:
+    async def test_create_job_with_user_id(self, db, user_a):
+        job = await db.create_job(content="Job desc", user_id=user_a["id"])
+        assert job["job_id"]
+
+    async def test_get_job_scoped(self, db, user_a, user_b):
+        job = await db.create_job(content="Job desc", user_id=user_a["id"])
+        assert await db.get_job(job["job_id"], user_id=user_a["id"]) is not None
+        assert await db.get_job(job["job_id"], user_id=user_b["id"]) is None
+
+    async def test_update_job_scoped(self, db, user_a, user_b):
+        job = await db.create_job(content="Job desc", user_id=user_a["id"])
+        updated = await db.update_job(job["job_id"], user_id=user_a["id"], updates={"content": "New"})
+        assert updated["content"] == "New"
+        assert await db.update_job(job["job_id"], user_id=user_b["id"], updates={"content": "Hack"}) is None
+
+
+# -- Improvement scoping --
+
+class TestImprovementScoping:
+    async def test_create_improvement_with_user_id(self, db, user_a):
+        resume = await db.create_resume(content="# R", user_id=user_a["id"])
+        tailored = await db.create_resume(content="# T", user_id=user_a["id"])
+        job = await db.create_job(content="JD", user_id=user_a["id"])
+        imp = await db.create_improvement(
+            original_resume_id=resume["resume_id"],
+            tailored_resume_id=tailored["resume_id"],
+            job_id=job["job_id"],
+            improvements=[],
+            user_id=user_a["id"],
+        )
+        assert imp["request_id"]
+
+    async def test_get_improvement_scoped(self, db, user_a, user_b):
+        resume = await db.create_resume(content="# R", user_id=user_a["id"])
+        tailored = await db.create_resume(content="# T", user_id=user_a["id"])
+        job = await db.create_job(content="JD", user_id=user_a["id"])
+        await db.create_improvement(
+            original_resume_id=resume["resume_id"],
+            tailored_resume_id=tailored["resume_id"],
+            job_id=job["job_id"],
+            improvements=[],
+            user_id=user_a["id"],
+        )
+        assert await db.get_improvement_by_tailored_resume(tailored["resume_id"], user_id=user_a["id"]) is not None
+        assert await db.get_improvement_by_tailored_resume(tailored["resume_id"], user_id=user_b["id"]) is None
+
+
+# -- Stats scoping --
+
+class TestStatsScoping:
+    async def test_stats_scoped_to_user(self, db, user_a, user_b):
+        await db.create_resume(content="# A", user_id=user_a["id"])
+        await db.create_resume(content="# B1", user_id=user_b["id"])
+        await db.create_resume(content="# B2", user_id=user_b["id"])
+        stats_a = await db.get_stats(user_id=user_a["id"])
+        assert stats_a["total_resumes"] == 1
+        stats_b = await db.get_stats(user_id=user_b["id"])
+        assert stats_b["total_resumes"] == 2
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `cd apps/backend && uv run pytest tests/unit/test_database_user_scoping.py::TestJobScoping -v`
+Expected: FAIL
+
+**Step 3: Implement user-scoped job, improvement, and stats operations**
+
+**`create_job`** — add `user_id: str` parameter:
+```python
+async def create_job(self, content: str, user_id: str, resume_id: str | None = None) -> dict[str, Any]:
+    job = Job(job_id=str(uuid4()), content=content, user_id=user_id, resume_id=resume_id)
+    async with self._session() as session:
+        session.add(job)
+        await session.commit()
+        await session.refresh(job)
+        return self._job_to_dict(job)
+```
+
+**`get_job`** — add `user_id: str`:
+```python
+async def get_job(self, job_id: str, user_id: str) -> dict[str, Any] | None:
+    async with self._session() as session:
+        result = await session.execute(
+            select(Job).where(Job.job_id == job_id, Job.user_id == user_id)
+        )
+        row = result.scalar_one_or_none()
+        return self._job_to_dict(row) if row else None
+```
+
+**`update_job`** — add `user_id: str`:
+```python
+async def update_job(self, job_id: str, user_id: str, updates: dict[str, Any]) -> dict[str, Any] | None:
+    async with self._session() as session:
+        result = await session.execute(
+            update(Job).where(Job.job_id == job_id, Job.user_id == user_id).values(**updates)
+        )
+        if result.rowcount == 0:
+            return None
+        await session.commit()
+    return await self.get_job(job_id, user_id)
+```
+
+**`create_improvement`** — add `user_id: str`:
+```python
+async def create_improvement(
+    self, original_resume_id: str, tailored_resume_id: str,
+    job_id: str, improvements: list[dict[str, Any]], user_id: str,
+) -> dict[str, Any]:
+    imp = Improvement(
+        request_id=str(uuid4()), original_resume_id=original_resume_id,
+        tailored_resume_id=tailored_resume_id, job_id=job_id,
+        improvements=improvements, user_id=user_id,
+    )
+    async with self._session() as session:
+        session.add(imp)
+        await session.commit()
+        await session.refresh(imp)
+        return self._improvement_to_dict(imp)
+```
+
+**`get_improvement_by_tailored_resume`** — add `user_id: str`:
+```python
+async def get_improvement_by_tailored_resume(self, tailored_resume_id: str, user_id: str) -> dict[str, Any] | None:
+    async with self._session() as session:
+        result = await session.execute(
+            select(Improvement).where(
+                Improvement.tailored_resume_id == tailored_resume_id,
+                Improvement.user_id == user_id,
+            )
+        )
+        row = result.scalar_one_or_none()
+        return self._improvement_to_dict(row) if row else None
+```
+
+**`get_stats`** — add `user_id: str`:
+```python
+async def get_stats(self, user_id: str) -> dict[str, Any]:
+    async with self._session() as session:
+        resume_count = (await session.execute(
+            select(func.count()).select_from(Resume).where(Resume.user_id == user_id)
+        )).scalar() or 0
+        job_count = (await session.execute(
+            select(func.count()).select_from(Job).where(Job.user_id == user_id)
+        )).scalar() or 0
+        improvement_count = (await session.execute(
+            select(func.count()).select_from(Improvement).where(Improvement.user_id == user_id)
+        )).scalar() or 0
+        master = await session.execute(
+            select(Resume).where(Resume.is_master == True, Resume.user_id == user_id)
+        )
+        return {
+            "total_resumes": resume_count,
+            "total_jobs": job_count,
+            "total_improvements": improvement_count,
+            "has_master_resume": master.scalar_one_or_none() is not None,
+        }
+```
+
+**Step 4: Run all scoping tests**
+
+Run: `cd apps/backend && uv run pytest tests/unit/test_database_user_scoping.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/app/database.py apps/backend/tests/unit/test_database_user_scoping.py
+git commit -m "feat(m4): add user_id scoping to job, improvement, and stats operations"
+```
+
+---
+
+### Task 4: Auth Test Fixtures
+
+**Files:**
+- Modify: `apps/backend/tests/conftest.py`
+
+**Step 1: Add auth fixture helpers**
+
+Add these fixtures to `apps/backend/tests/conftest.py`:
+
+```python
+from app.auth.jwt import create_access_token
+from app.config import settings
+
+
+@pytest.fixture
+async def auth_user_a(test_db):
+    """Create user A and return (user_dict, bearer_token)."""
+    user = await test_db.create_user(email="alice@test.com", hashed_password="hash_a", display_name="Alice")
+    token = create_access_token(user_id=user["id"], secret=settings.effective_jwt_secret)
+    return user, token
+
+
+@pytest.fixture
+async def auth_user_b(test_db):
+    """Create user B and return (user_dict, bearer_token)."""
+    user = await test_db.create_user(email="bob@test.com", hashed_password="hash_b", display_name="Bob")
+    token = create_access_token(user_id=user["id"], secret=settings.effective_jwt_secret)
+    return user, token
+
+
+@pytest.fixture
+def auth_headers_a(auth_user_a):
+    """Authorization headers for user A."""
+    _, token = auth_user_a
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def auth_headers_b(auth_user_b):
+    """Authorization headers for user B."""
+    _, token = auth_user_b
+    return {"Authorization": f"Bearer {token}"}
+```
+
+Also add the import for `create_access_token`. Check the actual function signature:
+
+```bash
+cd apps/backend && grep -n "def create_access_token" app/auth/jwt.py
+```
+
+Adapt the fixture if the signature differs.
+
+**Step 2: Verify fixtures work**
+
+Write a quick smoke test in `apps/backend/tests/integration/test_auth_fixtures_smoke.py`:
+
+```python
+"""Smoke test that auth fixtures produce valid tokens."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_auth_me_with_fixture(client, auth_headers_a):
+    resp = await client.get("/api/v1/auth/me", headers=auth_headers_a)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["email"] == "alice@test.com"
+```
+
+Run: `cd apps/backend && uv run pytest tests/integration/test_auth_fixtures_smoke.py -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add apps/backend/tests/conftest.py apps/backend/tests/integration/test_auth_fixtures_smoke.py
+git commit -m "feat(m4): add auth test fixtures for user A/B with JWT tokens"
+```
+
+---
+
+### Task 5: Resumes Router — Add Auth & Thread user_id
+
+**Files:**
+- Modify: `apps/backend/app/routers/resumes.py`
+
+This is the largest task. All 17 resume endpoints need:
+1. `Depends(get_current_user)` in their signature
+2. `user["id"]` passed to every `db.*` call
+
+**Step 1: Add import and auth dependency**
+
+At the top of `resumes.py`, add:
+```python
+from fastapi import Depends
+from app.auth.dependencies import get_current_user
+```
+
+**Step 2: Update all endpoint signatures and db calls**
+
+The pattern for every endpoint is the same. Here is each endpoint with the specific changes:
+
+**`upload_resume`** (line 509):
+```python
+async def upload_resume(file: UploadFile = File(...), user: dict = Depends(get_current_user)) -> ResumeUploadResponse:
+```
+Change `db.create_resume_atomic_master(...)` call to include `user_id=user["id"]`.
+Change `db.update_resume(resume["resume_id"], {...})` calls to `db.update_resume(resume["resume_id"], user["id"], {...})`.
+
+**`get_resume`** (line 588):
+```python
+async def get_resume(resume_id: str = Query(...), user: dict = Depends(get_current_user)) -> ResumeFetchResponse:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+
+**`list_resumes`** (line 638):
+```python
+async def list_resumes(include_master: bool = Query(False), user: dict = Depends(get_current_user)) -> ResumeListResponse:
+```
+Change `db.list_resumes()` to `db.list_resumes(user["id"])`.
+
+**`improve_resume_preview_endpoint`** (line 664):
+```python
+async def improve_resume_preview_endpoint(request: ImproveResumeRequest, user: dict = Depends(get_current_user)) -> ImproveResumeResponse:
+```
+Change `db.get_resume(request.resume_id)` to `db.get_resume(request.resume_id, user["id"])`.
+Change `db.get_job(request.job_id)` to `db.get_job(request.job_id, user["id"])`.
+Pass `user_id=user["id"]` to `_improve_preview_flow(...)`.
+
+**`_improve_preview_flow`** (line 710) — add `user_id: str` parameter:
+```python
+async def _improve_preview_flow(
+    *,
+    request: ImproveResumeRequest,
+    resume: dict[str, Any],
+    job: dict[str, Any],
+    language: str,
+    prompt_id: str,
+    user_id: str,
+) -> ImproveResumeResponse:
+```
+Change `db.update_job(request.job_id, {...})` to `db.update_job(request.job_id, user_id, {...})` (two occurrences: lines ~726 and ~869).
+Change `db.get_master_resume()` to `db.get_master_resume(user_id)` (line ~811).
+
+**`improve_resume_confirm_endpoint`** (line 922):
+```python
+async def improve_resume_confirm_endpoint(request: ImproveResumeConfirmRequest, user: dict = Depends(get_current_user)) -> ImproveResumeResponse:
+```
+Change `db.get_resume(request.resume_id)` to `db.get_resume(request.resume_id, user["id"])`.
+Change `db.get_job(request.job_id)` to `db.get_job(request.job_id, user["id"])`.
+Change `db.create_resume(...)` to include `user_id=user["id"]`.
+Change `db.create_improvement(...)` to include `user_id=user["id"]`.
+
+**`improve_resume_endpoint`** (line 1057):
+```python
+async def improve_resume_endpoint(request: ImproveResumeRequest, user: dict = Depends(get_current_user)) -> ImproveResumeResponse:
+```
+Change `db.get_resume(request.resume_id)` to `db.get_resume(request.resume_id, user["id"])`.
+Change `db.get_job(request.job_id)` to `db.get_job(request.job_id, user["id"])`.
+Change `db.get_master_resume()` to `db.get_master_resume(user["id"])`.
+Change `db.create_resume(...)` to include `user_id=user["id"]`.
+Change `db.create_improvement(...)` to include `user_id=user["id"]`.
+
+**`update_resume_endpoint`** (line 1299):
+```python
+async def update_resume_endpoint(resume_id: str, resume_data: ResumeData, user: dict = Depends(get_current_user)) -> ResumeFetchResponse:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+Change `db.update_resume(resume_id, {...})` to `db.update_resume(resume_id, user["id"], {...})`.
+
+**`download_resume_pdf`** (line 1348):
+```python
+async def download_resume_pdf(resume_id: str, ..., user: dict = Depends(get_current_user)) -> Response:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+
+**`delete_resume`** (line 1431):
+```python
+async def delete_resume(resume_id: str, user: dict = Depends(get_current_user)) -> dict:
+```
+Change `db.delete_resume(resume_id)` to `db.delete_resume(resume_id, user["id"])`.
+
+**`retry_processing`** (line 1440):
+```python
+async def retry_processing(resume_id: str, user: dict = Depends(get_current_user)) -> ResumeUploadResponse:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+Change both `db.update_resume(resume_id, {...})` calls to include `user["id"]`.
+
+**`update_cover_letter`** (line 1492):
+```python
+async def update_cover_letter(resume_id: str, request: UpdateCoverLetterRequest, user: dict = Depends(get_current_user)) -> dict:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+Change `db.update_resume(resume_id, {...})` to `db.update_resume(resume_id, user["id"], {...})`.
+
+**`update_outreach_message`** (line 1505):
+```python
+async def update_outreach_message(resume_id: str, request: UpdateOutreachMessageRequest, user: dict = Depends(get_current_user)) -> dict:
+```
+Same pattern as `update_cover_letter`.
+
+**`update_title`** (line 1518):
+```python
+async def update_title(resume_id: str, request: UpdateTitleRequest, user: dict = Depends(get_current_user)) -> dict:
+```
+Same pattern.
+
+**`generate_cover_letter_endpoint`** (line 1530):
+```python
+async def generate_cover_letter_endpoint(resume_id: str, user: dict = Depends(get_current_user)) -> GenerateContentResponse:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+Change `db.get_improvement_by_tailored_resume(resume_id)` to `db.get_improvement_by_tailored_resume(resume_id, user["id"])`.
+Change `db.get_job(improvement["job_id"])` to `db.get_job(improvement["job_id"], user["id"])`.
+Change `db.update_resume(resume_id, {...})` to `db.update_resume(resume_id, user["id"], {...})`.
+
+**`generate_outreach_endpoint`** (line 1603):
+Same pattern as `generate_cover_letter_endpoint`.
+
+**`get_job_description_for_resume`** (line 1674):
+```python
+async def get_job_description_for_resume(resume_id: str, user: dict = Depends(get_current_user)) -> dict:
+```
+Change all three db calls to include `user["id"]`.
+
+**`download_cover_letter_pdf`** (line 1716):
+```python
+async def download_cover_letter_pdf(resume_id: str, ..., user: dict = Depends(get_current_user)) -> Response:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+
+**Step 3: Commit**
+
+```bash
+git add apps/backend/app/routers/resumes.py
+git commit -m "feat(m4): add auth to all resume endpoints, thread user_id to db calls"
+```
+
+---
+
+### Task 6: Jobs Router — Add Auth
+
+**Files:**
+- Modify: `apps/backend/app/routers/jobs.py`
+
+**Step 1: Add auth dependency and thread user_id**
+
+```python
+from fastapi import APIRouter, Depends, HTTPException
+from app.auth.dependencies import get_current_user
+from app.database import db
+from app.schemas import JobUploadRequest, JobUploadResponse
+
+router = APIRouter(prefix="/jobs", tags=["Jobs"])
+
+
+@router.post("/upload", response_model=JobUploadResponse)
+async def upload_job_descriptions(
+    request: JobUploadRequest, user: dict = Depends(get_current_user)
+) -> JobUploadResponse:
+    if not request.job_descriptions:
+        raise HTTPException(status_code=400, detail="No job descriptions provided")
+
+    job_ids = []
+    for jd in request.job_descriptions:
+        if not jd.strip():
+            raise HTTPException(status_code=400, detail="Empty job description")
+        job = await db.create_job(
+            content=jd.strip(),
+            user_id=user["id"],
+            resume_id=request.resume_id,
+        )
+        job_ids.append(job["job_id"])
+
+    return JobUploadResponse(
+        message="data successfully processed",
+        job_id=job_ids,
+        request={
+            "job_descriptions": request.job_descriptions,
+            "resume_id": request.resume_id,
+        },
+    )
+
+
+@router.get("/{job_id}")
+async def get_job(job_id: str, user: dict = Depends(get_current_user)) -> dict:
+    job = await db.get_job(job_id, user["id"])
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+```
+
+**Step 2: Commit**
+
+```bash
+git add apps/backend/app/routers/jobs.py
+git commit -m "feat(m4): add auth to jobs endpoints, thread user_id"
+```
+
+---
+
+### Task 7: Enrichment Router — Add Auth
+
+**Files:**
+- Modify: `apps/backend/app/routers/enrichment.py`
+
+**Step 1: Add auth and thread user_id to all 5 endpoints**
+
+Add imports:
+```python
+from fastapi import APIRouter, Depends, HTTPException
+from app.auth.dependencies import get_current_user
+```
+
+Update each endpoint:
+
+**`analyze_resume`** (line 87):
+```python
+async def analyze_resume(resume_id: str, user: dict = Depends(get_current_user)) -> AnalysisResponse:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+
+**`generate_enhancements`** (line 157):
+```python
+async def generate_enhancements(request: EnhanceRequest, user: dict = Depends(get_current_user)) -> EnhancementPreview:
+```
+Change `db.get_resume(request.resume_id)` to `db.get_resume(request.resume_id, user["id"])`.
+
+**`apply_enhancements`** (line 298):
+```python
+async def apply_enhancements(resume_id: str, request: ApplyEnhancementsRequest, user: dict = Depends(get_current_user)) -> dict:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+Change `db.update_resume(resume_id, {...})` to `db.update_resume(resume_id, user["id"], {...})`.
+
+**`regenerate_items`** (line 457):
+```python
+async def regenerate_items(request: RegenerateRequest, user: dict = Depends(get_current_user)) -> RegenerateResponse:
+```
+Change `db.get_resume(request.resume_id)` to `db.get_resume(request.resume_id, user["id"])`.
+
+**`apply_regenerated_items`** (line 517):
+```python
+async def apply_regenerated_items(resume_id: str, regenerated_items: list[RegeneratedItem], user: dict = Depends(get_current_user)) -> dict:
+```
+Change `db.get_resume(resume_id)` to `db.get_resume(resume_id, user["id"])`.
+Change `db.update_resume(resume_id, {...})` to `db.update_resume(resume_id, user["id"], {...})`.
+
+**Step 2: Commit**
+
+```bash
+git add apps/backend/app/routers/enrichment.py
+git commit -m "feat(m4): add auth to enrichment endpoints, thread user_id"
+```
+
+---
+
+### Task 8: Health Status — Add Auth
+
+**Files:**
+- Modify: `apps/backend/app/routers/health.py`
+
+**Step 1: Add auth to get_status only**
+
+```python
+from fastapi import APIRouter, Depends
+from app.auth.dependencies import get_current_user
+from app.database import db
+from app.llm import check_llm_health, get_llm_config
+from app.schemas import HealthResponse, StatusResponse
+
+router = APIRouter(tags=["Health"])
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health_check() -> HealthResponse:
+    """Basic health check endpoint — stays public."""
+    llm_status = await check_llm_health()
+    return HealthResponse(
+        status="healthy" if llm_status["healthy"] else "degraded",
+        llm=llm_status,
+    )
+
+
+@router.get("/status", response_model=StatusResponse)
+async def get_status(user: dict = Depends(get_current_user)) -> StatusResponse:
+    """Get user-scoped application status."""
+    config = get_llm_config()
+    llm_status = await check_llm_health(config)
+    db_stats = await db.get_stats(user["id"])
+
+    return StatusResponse(
+        status="ready" if llm_status["healthy"] and db_stats["has_master_resume"] else "setup_required",
+        llm_configured=bool(config.api_key) or config.provider == "ollama",
+        llm_healthy=llm_status["healthy"],
+        has_master_resume=db_stats["has_master_resume"],
+        database_stats=db_stats,
+    )
+```
+
+**Step 2: Commit**
+
+```bash
+git add apps/backend/app/routers/health.py
+git commit -m "feat(m4): add auth to /status endpoint, scope stats to user"
+```
+
+---
+
+### Task 9: Integration Tests — Auth Enforcement & Isolation
+
+**Files:**
+- Create: `apps/backend/tests/integration/test_data_isolation.py`
+
+**Step 1: Write auth enforcement and isolation tests**
+
+```python
+"""Integration tests for multi-user data isolation."""
+
+import json
+import pytest
+
+
+# -- 401 for unauthenticated requests --
+
+class TestAuthEnforcement:
+    """All data endpoints must return 401 without a Bearer token."""
+
+    PROTECTED_ENDPOINTS = [
+        ("GET", "/api/v1/resumes?resume_id=fake"),
+        ("GET", "/api/v1/resumes/list"),
+        ("GET", "/api/v1/resumes/fake/pdf"),
+        ("DELETE", "/api/v1/resumes/fake"),
+        ("GET", "/api/v1/resumes/fake/job-description"),
+        ("GET", "/api/v1/jobs/fake"),
+        ("GET", "/api/v1/status"),
+    ]
+
+    @pytest.mark.parametrize("method,path", PROTECTED_ENDPOINTS)
+    async def test_returns_401_without_token(self, client, method, path):
+        resp = await client.request(method, path)
+        assert resp.status_code == 401
+
+
+class TestResumeIsolation:
+    """User A's resumes are invisible to User B."""
+
+    async def test_user_b_cannot_see_user_a_resume(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        _, token_b = auth_user_b
+        headers_a = {"Authorization": f"Bearer {token_a}"}
+        headers_b = {"Authorization": f"Bearer {token_b}"}
+
+        # User A creates a resume via DB directly
+        resume = await test_db.create_resume(content="# Secret", user_id=user_a["id"])
+        rid = resume["resume_id"]
+
+        # User A can see it
+        resp = await client.get(f"/api/v1/resumes?resume_id={rid}", headers=headers_a)
+        assert resp.status_code == 200
+
+        # User B gets 404
+        resp = await client.get(f"/api/v1/resumes?resume_id={rid}", headers=headers_b)
+        assert resp.status_code == 404
+
+    async def test_list_resumes_only_shows_own(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        user_b, token_b = auth_user_b
+
+        await test_db.create_resume(content="# A1", user_id=user_a["id"])
+        await test_db.create_resume(content="# A2", user_id=user_a["id"])
+        await test_db.create_resume(content="# B1", user_id=user_b["id"])
+
+        resp = await client.get(
+            "/api/v1/resumes/list?include_master=true",
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()["data"]
+        assert len(data) == 2
+
+    async def test_user_b_cannot_delete_user_a_resume(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, _ = auth_user_a
+        _, token_b = auth_user_b
+
+        resume = await test_db.create_resume(content="# A", user_id=user_a["id"])
+
+        resp = await client.delete(
+            f"/api/v1/resumes/{resume['resume_id']}",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert resp.status_code == 404
+
+        # Resume still exists for user A
+        still_exists = await test_db.get_resume(resume["resume_id"], user_a["id"])
+        assert still_exists is not None
+
+
+class TestJobIsolation:
+    async def test_user_b_cannot_see_user_a_job(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        _, token_b = auth_user_b
+
+        job = await test_db.create_job(content="JD text", user_id=user_a["id"])
+
+        resp = await client.get(
+            f"/api/v1/jobs/{job['job_id']}",
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get(
+            f"/api/v1/jobs/{job['job_id']}",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+        assert resp.status_code == 404
+
+
+class TestStatusScoping:
+    async def test_status_returns_user_stats(self, client, test_db, auth_user_a, auth_user_b):
+        user_a, token_a = auth_user_a
+        user_b, token_b = auth_user_b
+
+        await test_db.create_resume(content="# A", user_id=user_a["id"], is_master=True)
+
+        resp = await client.get("/api/v1/status", headers={"Authorization": f"Bearer {token_a}"})
+        assert resp.status_code == 200
+        assert resp.json()["database_stats"]["total_resumes"] == 1
+        assert resp.json()["has_master_resume"] is True
+
+        resp = await client.get("/api/v1/status", headers={"Authorization": f"Bearer {token_b}"})
+        assert resp.status_code == 200
+        assert resp.json()["database_stats"]["total_resumes"] == 0
+        assert resp.json()["has_master_resume"] is False
+```
+
+**Step 2: Run isolation tests**
+
+Run: `cd apps/backend && uv run pytest tests/integration/test_data_isolation.py -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add apps/backend/tests/integration/test_data_isolation.py
+git commit -m "test(m4): add auth enforcement and cross-user isolation tests"
+```
+
+---
+
+### Task 10: Frontend — Switch to authFetch
+
+**Files:**
+- Modify: `apps/frontend/lib/api/resume.ts`
+- Modify: `apps/frontend/lib/api/enrichment.ts`
+- Modify: `apps/frontend/lib/api/config.ts` (only `/status` call)
+
+**Step 1: Update resume.ts**
+
+Replace the import:
+```typescript
+// Before:
+import { API_BASE, apiPost, apiPatch, apiDelete, apiFetch } from './client';
+// After:
+import { API_BASE, authFetch } from './client';
+```
+
+Replace every `apiFetch(...)`, `apiPost(...)`, `apiPatch(...)`, `apiDelete(...)` call with `authFetch(...)` using appropriate options:
+
+- `apiPost(endpoint, body, timeout)` → `authFetch(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }, timeout)`
+- `apiPatch(endpoint, body)` → `authFetch(endpoint, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })`
+- `apiDelete(endpoint)` → `authFetch(endpoint, { method: 'DELETE' })`
+- `apiFetch(endpoint)` → `authFetch(endpoint)`
+- `apiFetch(url)` for absolute URLs → `authFetch(url)`
+
+The `getResumePdfUrl` and `getCoverLetterPdfUrl` functions return URL strings (used in `<a>` tags or `window.open`), not fetch calls. These stay unchanged — PDF downloads opened in a new tab won't have the token. If PDF downloads need auth in the future, that's a separate concern.
+
+Wait — `downloadResumePdf` and `downloadCoverLetterPdf` DO use `apiFetch` to fetch the blob. Change those to `authFetch`.
+
+**Step 2: Update enrichment.ts**
+
+Replace the import:
+```typescript
+// Before:
+import { apiFetch, apiPost } from './client';
+// After:
+import { authFetch } from './client';
+```
+
+Replace all calls:
+- `apiFetch(url, { method: 'POST', credentials: 'include' })` → `authFetch(url, { method: 'POST' })`
+- `apiPost(endpoint, body)` → `authFetch(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })`
+
+**Step 3: Update config.ts — only `/status`**
+
+Find the `getStatus` function (or equivalent) that calls `apiFetch('/status', ...)` and change it to `authFetch('/status', ...)`. Leave all other config calls unchanged.
+
+**Step 4: Run lint**
+
+Run: `cd apps/frontend && npm run lint`
+Expected: PASS (no unused imports, etc.)
+
+**Step 5: Commit**
+
+```bash
+git add apps/frontend/lib/api/resume.ts apps/frontend/lib/api/enrichment.ts apps/frontend/lib/api/config.ts
+git commit -m "feat(m4): switch frontend data API calls to authFetch"
+```
+
+---
+
+### Task 11: Fix Existing Integration Tests
+
+**Files:**
+- Modify: `apps/backend/tests/integration/test_resume_api.py`
+- Modify: `apps/backend/tests/integration/test_jobs_api.py`
+- Modify: `apps/backend/tests/integration/test_health_api.py`
+- Modify: `apps/backend/tests/integration/test_config_api.py`
+- Modify: `apps/backend/tests/integration/test_regenerate_endpoints.py`
+- Modify: `apps/backend/tests/unit/test_database.py`
+
+**Step 1: Identify all failing tests**
+
+Run: `cd apps/backend && uv run pytest --tb=short 2>&1 | head -100`
+
+Every integration test that calls data endpoints without auth will fail with 401.
+Every unit test that calls DB methods without `user_id` will fail with TypeError.
+
+**Step 2: Fix unit/test_database.py**
+
+Any test calling `db.create_resume()`, `db.get_resume()`, etc. needs the `user_id` parameter added. Create a user first:
+
+```python
+user = await db.create_user(email="test@test.com")
+resume = await db.create_resume(content="# Test", user_id=user["id"])
+fetched = await db.get_resume(resume["resume_id"], user["id"])
+```
+
+**Step 3: Fix integration tests**
+
+For each integration test file, add the `auth_headers_a` fixture and pass headers to requests:
+
+```python
+# Before:
+resp = await client.get("/api/v1/resumes/list")
+
+# After:
+resp = await client.get("/api/v1/resumes/list", headers=auth_headers_a)
+```
+
+For tests that create data via db directly, also add `user_id`:
+```python
+# Before:
+resume = await test_db.create_resume(content="# Test")
+
+# After:
+user, _ = auth_user_a
+resume = await test_db.create_resume(content="# Test", user_id=user["id"])
+```
+
+For `test_health_api.py`, the `GET /status` test needs auth headers. The `GET /health` test stays unchanged (public).
+
+For `test_config_api.py`, tests are unchanged (config endpoints are deferred, still unauthenticated).
+
+**Step 4: Run full test suite**
+
+Run: `cd apps/backend && uv run pytest -v`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add apps/backend/tests/
+git commit -m "fix(m4): update existing tests for user_id scoping and auth requirements"
+```
+
+---
+
+### Task 12: Final Verification & Cleanup
+
+**Step 1: Run full backend test suite**
+
+```bash
+cd apps/backend && uv run pytest -v --tb=short
+```
+
+Expected: ALL PASS
+
+**Step 2: Run frontend lint**
+
+```bash
+cd apps/frontend && npm run lint
+```
+
+Expected: PASS
+
+**Step 3: Run frontend format**
+
+```bash
+cd apps/frontend && npm run format
+```
+
+**Step 4: Final commit if any format changes**
+
+```bash
+git add -A
+git commit -m "chore(m4): format and lint cleanup"
+```
+
+**Step 5: Create PR**
+
+Create a PR targeting `fork/main` with title: `feat: M4 multi-user data isolation`

--- a/docs/plans/2026-04-03-m5-mcp-oauth-design.md
+++ b/docs/plans/2026-04-03-m5-mcp-oauth-design.md
@@ -1,0 +1,110 @@
+# M5: MCP OAuth 2.1 (Claude Integration) -- Design Document
+
+**Goal:** Make Resume Matcher usable as an MCP server by claude.ai, with RS256 JWT signing, Dynamic Client Registration, JWKS, RFC 9728 metadata, and MCP tool endpoints.
+
+**Architecture:** Full RS256 migration (replaces HS256 for JWT). Simple JSON-RPC handler for MCP protocol (no SDK dependency). OAuth 2.1 infrastructure extended with DCR + JWKS. claude.ai compatibility proxies at root level.
+
+**Tech Stack:** joserfc (RSA key management + JWT), FastAPI, SQLAlchemy, Alembic.
+
+---
+
+## Understanding Summary
+
+- **What:** RS256 JWT migration, JWKS endpoint, RFC 9728 metadata, Dynamic Client Registration (RFC 7591), MCP tool endpoints with OAuth auth, claude.ai compatibility layer
+- **Why:** Enable claude.ai (and future MCP clients) to authenticate and use Resume Matcher as an AI tool server
+- **Who:** claude.ai as primary MCP client; any MCP-compatible AI assistant
+- **Key constraints:** Build on M2 auth (joserfc, SQLAlchemy, FastAPI); handle claude.ai DCR quirk (omits `token_endpoint_auth_method`); single-server deployment
+- **Non-goals:** API key fallback, fine-grained OAuth scopes, consent screen, key rotation, rate limiting on DCR, MCP SDK dependency
+
+## Assumptions
+
+1. No production users exist -- breaking JWT format change (HS256 to RS256) is safe
+2. Single RS256 key pair is sufficient (no rotation needed yet)
+3. claude.ai is the only expected MCP client (but DCR is open for others)
+4. HMAC operations (Google OAuth state packing) continue using `jwt_secret_key`
+5. MCP protocol implementation is JSON-RPC 2.0 over HTTP (no MCP SDK needed)
+6. claude.ai web quirk: ignores AS metadata URLs, appends `/authorize`, `/token`, `/register` to server root
+
+## Decision Log
+
+| # | Decision | Alternatives | Rationale |
+|---|----------|-------------|-----------|
+| 1 | Full RS256 migration | Dual HS256/RS256 | No production users; one signing path is simpler |
+| 2 | Drop API key fallback | Bearer + API key | No existing API key users; YAGNI |
+| 3 | No fine-grained scopes | MCP-specific scopes | Same approach as Reactive Resume; add later if needed |
+| 4 | No consent screen | Per-client consent | Only expected client is claude.ai; YAGNI |
+| 5 | PEM file + env var for RSA key | DB-stored keys, cloud KMS | Single server; file/env is simplest |
+| 6 | No MCP SDK dependency | Use `mcp` Python package | MCP is just JSON-RPC; direct handler is simpler, fewer deps |
+| 7 | Root-level proxy endpoints for claude.ai | Move all OAuth to root | Proxy keeps existing `/api/v1` structure intact |
+| 8 | Seed first-party client into `oauth_clients` table | Keep hardcoded constant | One validation path for all clients |
+| 9 | Streamable HTTP (POST) not legacy SSE | SSE transport | Per-request auth; SSE deprecated in MCP spec |
+| 10 | `token_endpoint_auth_method` defaults to `none` | Reject missing value | Known claude.ai quirk |
+| 11 | Keep `jwt_secret_key` for HMAC operations | Derive from RSA key | Clean separation; Google OAuth state packing unchanged |
+| 12 | Module-level key cache in `keys.py` | Settings property, DI container | Simple, testable via `reset_keys()` |
+
+---
+
+## Design
+
+### 1. RSA Key Management (`app/auth/keys.py`)
+
+Module-level cache. Keys loaded once at app startup via `load_rsa_keys()`, accessed via `get_private_key()`, `get_public_key()`, `get_kid()`, `get_jwks()`. `reset_keys()` for test cleanup.
+
+Key loading priority: env var `RSA_PRIVATE_KEY_PEM` > file `data/jwt_rsa_private.pem` > auto-generate.
+
+`kid` = SHA-256 JWK thumbprint of public key (deterministic, stable).
+
+### 2. RS256 JWT Migration
+
+- `jwt.py`: `OctKey` -> `RSAKey`, `HS256` -> `RS256`. Remove `secret` parameter; use module-level keys.
+- `dependencies.py`: Remove `settings.effective_jwt_secret` from verify calls.
+- `oauth.py`: Remove `settings.effective_jwt_secret` from sign calls.
+- `main.py` lifespan: Call `load_rsa_keys()` at startup.
+- HMAC operations (Google OAuth `pack_state`/`unpack_state`) continue using `settings.effective_jwt_secret`.
+
+### 3. JWKS Endpoint
+
+`GET /.well-known/jwks.json` in `main.py`. Returns public key via `get_jwks()`.
+
+### 4. RFC 9728 Protected Resource Metadata
+
+`GET /.well-known/oauth-protected-resource` in `main.py`. Returns `resource`, `authorization_servers` (self), `bearer_methods_supported`.
+
+### 5. OAuthClient Model + Migration
+
+New model in `models.py`. Alembic migration creates table and seeds `resume-matcher-web` with existing redirect URIs. CRUD methods in `database.py`.
+
+### 6. Dynamic Client Registration
+
+`POST /api/v1/oauth/register` in `oauth.py`. Accepts `redirect_uris`, `client_name`, `token_endpoint_auth_method` (default `"none"`), `grant_types`, `response_types`. Returns `client_id` (UUID) + echoed metadata.
+
+### 7. DB-Based Client Validation
+
+`_validate_client()` in `oauth.py` queries `oauth_clients` table instead of hardcoded constant. Validates `redirect_uri` against client's registered URIs.
+
+### 8. claude.ai Compatibility Endpoints
+
+Root-level in `main.py`:
+- `GET /authorize` -> 302 to `/api/v1/oauth/authorize`
+- `POST /token` -> forward to `/api/v1/oauth/token`
+- `POST /register` -> forward to `/api/v1/oauth/register`
+
+### 9. MCP Endpoint
+
+`app/routers/mcp.py` -- JSON-RPC 2.0 handler at `/mcp`.
+
+Methods:
+- `initialize` -> capabilities (no auth)
+- `notifications/initialized` -> 204 (no auth)
+- `tools/list` -> tool definitions (auth required)
+- `tools/call` -> execute tool (auth required)
+
+Tools: `list_resumes`, `get_resume`, `upload_resume`, `set_master_resume`, `upload_job_description`, `tailor_resume`, `get_tailoring_result`, `generate_cover_letter`
+
+Auth: Extract Bearer token, verify RS256 JWT, resolve user, pass to tool handler.
+
+### 10. Testing
+
+- Unit: RSA key gen/load, JWT RS256 roundtrip, JWKS format, DCR validation
+- Integration: Full MCP auth flow, metadata endpoints, claude.ai compat proxies
+- Isolation: MCP tools respect user scoping

--- a/docs/plans/2026-04-03-m5-mcp-oauth-design.md
+++ b/docs/plans/2026-04-03-m5-mcp-oauth-design.md
@@ -99,7 +99,7 @@ Methods:
 - `tools/list` -> tool definitions (auth required)
 - `tools/call` -> execute tool (auth required)
 
-Tools: `list_resumes`, `get_resume`, `upload_resume`, `set_master_resume`, `upload_job_description`, `tailor_resume`, `get_tailoring_result`, `generate_cover_letter`
+Tools: `list_resumes`, `get_resume`, `get_status`, `upload_job_description`, `set_master_resume`
 
 Auth: Extract Bearer token, verify RS256 JWT, resolve user, pass to tool handler.
 

--- a/docs/plans/2026-04-03-m5-mcp-oauth-implementation-plan.md
+++ b/docs/plans/2026-04-03-m5-mcp-oauth-implementation-plan.md
@@ -1,0 +1,1875 @@
+# M5: MCP OAuth 2.1 (Claude Integration) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable claude.ai to authenticate against Resume Matcher via OAuth 2.1 and use it as an MCP tool server.
+
+**Architecture:** Migrate JWT signing from HS256 to RS256 (asymmetric keys for public verification). Add JWKS, RFC 9728, and Dynamic Client Registration endpoints. Implement MCP protocol handler (JSON-RPC 2.0 over HTTP) with tool definitions that call existing service functions. Root-level proxy endpoints for claude.ai web compatibility.
+
+**Tech Stack:** joserfc (RSAKey for RS256), FastAPI, SQLAlchemy 2.0 async, Alembic.
+
+---
+
+## Context for Implementer
+
+### What exists (from M2/M3/M4):
+- `app/auth/jwt.py` -- HS256 JWT with `create_access_token(user_id, email, secret)` and `verify_access_token(token, secret)`
+- `app/auth/dependencies.py` -- `get_current_user` extracts Bearer token, verifies with `settings.effective_jwt_secret`
+- `app/auth/constants.py` -- `FIRST_PARTY_CLIENT_ID = "resume-matcher-web"`, redirect URIs, token lifetimes
+- `app/auth/pkce.py` -- PKCE S256 verification
+- `app/routers/oauth.py` -- `/oauth/authorize`, `/oauth/token`, `/oauth/revoke`; `_validate_client()` checks hardcoded client ID
+- `app/routers/google_oauth.py` -- Uses `settings.effective_jwt_secret` for HMAC state packing (NOT JWT; this stays on HMAC)
+- `app/main.py:86-102` -- RFC 8414 metadata at `/.well-known/oauth-authorization-server`
+- `app/models.py` -- User, Resume, Job, Improvement, AuthorizationCode, RefreshToken, OAuthAccount
+- `app/database.py` -- Async SQLAlchemy CRUD for all models
+- `app/config.py` -- `jwt_secret_key`, `effective_jwt_secret` property
+- `tests/conftest.py` -- `jwt_secret`, `rsa_keys`, `auth_user_a/b`, `auth_headers_a/b`, `client` fixtures
+- Latest Alembic revision: `a1b2c3d4e5f6`
+
+### Key principle:
+- `jwt_secret_key` / `effective_jwt_secret` continues to be used for HMAC operations (Google OAuth state packing)
+- RSA keys are a NEW, separate concern used only for JWT signing/verification
+- All existing tests must continue to pass after RS256 migration
+
+---
+
+## Task 1: RSA Key Management Module
+
+**Files:**
+- Create: `apps/backend/app/auth/keys.py`
+- Modify: `apps/backend/app/config.py` (add RSA settings)
+- Create: `apps/backend/tests/unit/test_rsa_keys.py`
+
+### Step 1: Write tests for RSA key management
+
+Create `apps/backend/tests/unit/test_rsa_keys.py`:
+
+```python
+"""Tests for RSA key management."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app.auth.keys import (
+    compute_kid,
+    get_jwks,
+    get_kid,
+    get_private_key,
+    get_public_key,
+    load_rsa_keys,
+    reset_keys,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_keys():
+    """Reset key cache before and after each test."""
+    reset_keys()
+    yield
+    reset_keys()
+
+
+class TestKeyGeneration:
+    def test_generate_keys_when_no_source(self):
+        """Auto-generates RSA key pair when no PEM or file provided."""
+        priv, pub, kid = load_rsa_keys()
+        assert priv is not None
+        assert pub is not None
+        assert isinstance(kid, str)
+        assert len(kid) > 0
+
+    def test_generated_key_is_2048_bit(self):
+        priv, _, _ = load_rsa_keys()
+        # RSA 2048-bit key has modulus of 256 bytes
+        d = priv.as_dict(private=True)
+        import base64
+        n_bytes = base64.urlsafe_b64decode(d["n"] + "==")
+        assert len(n_bytes) == 256
+
+    def test_keys_cached_after_first_load(self):
+        priv1, pub1, kid1 = load_rsa_keys()
+        priv2, pub2, kid2 = load_rsa_keys()
+        assert kid1 == kid2
+
+    def test_reset_clears_cache(self):
+        load_rsa_keys()
+        reset_keys()
+        with pytest.raises(RuntimeError, match="not loaded"):
+            get_private_key()
+
+
+class TestKeyLoading:
+    def test_load_from_pem_string(self):
+        from joserfc.jwk import RSAKey
+        key = RSAKey.generate_key(2048)
+        pem = key.as_pem(private=True)
+        priv, pub, kid = load_rsa_keys(pem_data=pem)
+        assert priv.as_dict(private=False)["n"] == key.as_dict(private=False)["n"]
+
+    def test_load_from_file(self, tmp_path):
+        from joserfc.jwk import RSAKey
+        key = RSAKey.generate_key(2048)
+        pem_file = tmp_path / "test_key.pem"
+        pem_file.write_text(key.as_pem(private=True))
+        priv, pub, kid = load_rsa_keys(key_file=pem_file)
+        assert priv.as_dict(private=False)["n"] == key.as_dict(private=False)["n"]
+
+    def test_auto_generate_saves_to_file(self, tmp_path):
+        pem_file = tmp_path / "auto_key.pem"
+        assert not pem_file.exists()
+        load_rsa_keys(key_file=pem_file)
+        assert pem_file.exists()
+        assert "BEGIN RSA PRIVATE KEY" in pem_file.read_text() or "BEGIN PRIVATE KEY" in pem_file.read_text()
+
+    def test_pem_data_takes_priority_over_file(self, tmp_path):
+        from joserfc.jwk import RSAKey
+        key1 = RSAKey.generate_key(2048)
+        key2 = RSAKey.generate_key(2048)
+        pem_file = tmp_path / "key.pem"
+        pem_file.write_text(key2.as_pem(private=True))
+        priv, _, _ = load_rsa_keys(pem_data=key1.as_pem(private=True), key_file=pem_file)
+        assert priv.as_dict(private=False)["n"] == key1.as_dict(private=False)["n"]
+
+
+class TestJWKS:
+    def test_jwks_format(self):
+        load_rsa_keys()
+        jwks = get_jwks()
+        assert "keys" in jwks
+        assert len(jwks["keys"]) == 1
+        key = jwks["keys"][0]
+        assert key["kty"] == "RSA"
+        assert key["use"] == "sig"
+        assert key["alg"] == "RS256"
+        assert "kid" in key
+        assert "n" in key
+        assert "e" in key
+        # Must NOT include private key components
+        assert "d" not in key
+        assert "p" not in key
+        assert "q" not in key
+
+    def test_kid_is_deterministic(self):
+        from joserfc.jwk import RSAKey
+        key = RSAKey.generate_key(2048)
+        pem = key.as_pem(private=True)
+        load_rsa_keys(pem_data=pem)
+        kid1 = get_kid()
+        reset_keys()
+        load_rsa_keys(pem_data=pem)
+        kid2 = get_kid()
+        assert kid1 == kid2
+
+
+class TestAccessors:
+    def test_get_private_key_raises_before_load(self):
+        with pytest.raises(RuntimeError):
+            get_private_key()
+
+    def test_get_public_key_raises_before_load(self):
+        with pytest.raises(RuntimeError):
+            get_public_key()
+
+    def test_get_kid_raises_before_load(self):
+        with pytest.raises(RuntimeError):
+            get_kid()
+
+    def test_accessors_work_after_load(self):
+        load_rsa_keys()
+        assert get_private_key() is not None
+        assert get_public_key() is not None
+        assert get_kid() is not None
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_rsa_keys.py -v
+```
+Expected: ImportError -- `app.auth.keys` does not exist yet.
+
+### Step 3: Implement RSA key management
+
+Create `apps/backend/app/auth/keys.py`:
+
+```python
+"""RSA key management for JWT signing (RS256)."""
+
+import base64
+import hashlib
+import json
+import logging
+from pathlib import Path
+
+from joserfc.jwk import RSAKey
+
+logger = logging.getLogger(__name__)
+
+_cached_keys: tuple[RSAKey, RSAKey, str] | None = None
+
+
+def compute_kid(public_key: RSAKey) -> str:
+    """Compute key ID as JWK Thumbprint (RFC 7638) of the public key."""
+    d = public_key.as_dict(private=False)
+    # Required members for RSA in lexicographic order
+    canonical = json.dumps(
+        {"e": d["e"], "kty": "RSA", "n": d["n"]},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    digest = hashlib.sha256(canonical.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def load_rsa_keys(
+    pem_data: str | None = None,
+    key_file: Path | None = None,
+) -> tuple[RSAKey, RSAKey, str]:
+    """Load or generate RSA key pair. Call once at app startup.
+
+    Priority: pem_data > key_file > auto-generate (saved to key_file if given).
+    """
+    global _cached_keys
+    if _cached_keys is not None:
+        return _cached_keys
+
+    if pem_data:
+        private_key = RSAKey.import_key(pem_data)
+        logger.info("Loaded RSA key from PEM data")
+    elif key_file and key_file.exists():
+        private_key = RSAKey.import_key(key_file.read_text())
+        logger.info("Loaded RSA key from %s", key_file)
+    else:
+        private_key = RSAKey.generate_key(2048)
+        logger.info("Generated new 2048-bit RSA key pair")
+        if key_file:
+            key_file.parent.mkdir(parents=True, exist_ok=True)
+            key_file.write_text(private_key.as_pem(private=True))
+            logger.info("Saved RSA private key to %s", key_file)
+
+    public_key = RSAKey.import_key(private_key.as_dict(private=False))
+    kid = compute_kid(public_key)
+
+    _cached_keys = (private_key, public_key, kid)
+    return _cached_keys
+
+
+def get_private_key() -> RSAKey:
+    """Get the cached RSA private key. Raises RuntimeError if not loaded."""
+    if _cached_keys is None:
+        raise RuntimeError("RSA keys not loaded. Call load_rsa_keys() first.")
+    return _cached_keys[0]
+
+
+def get_public_key() -> RSAKey:
+    """Get the cached RSA public key. Raises RuntimeError if not loaded."""
+    if _cached_keys is None:
+        raise RuntimeError("RSA keys not loaded. Call load_rsa_keys() first.")
+    return _cached_keys[1]
+
+
+def get_kid() -> str:
+    """Get the cached key ID. Raises RuntimeError if not loaded."""
+    if _cached_keys is None:
+        raise RuntimeError("RSA keys not loaded. Call load_rsa_keys() first.")
+    return _cached_keys[2]
+
+
+def get_jwks() -> dict:
+    """Return the public key in JWKS format (RFC 7517)."""
+    pub = get_public_key()
+    key_dict = pub.as_dict(private=False)
+    key_dict["kid"] = get_kid()
+    key_dict["use"] = "sig"
+    key_dict["alg"] = "RS256"
+    return {"keys": [key_dict]}
+
+
+def reset_keys() -> None:
+    """Reset cached keys. For testing only."""
+    global _cached_keys
+    _cached_keys = None
+```
+
+### Step 4: Add RSA config settings
+
+Modify `apps/backend/app/config.py`. Add these fields to the `Settings` class (after the Google OAuth section, around line 165):
+
+```python
+    # RSA Key Configuration (for RS256 JWT signing)
+    rsa_private_key_pem: str = ""
+    rsa_key_file: str = ""
+
+    @property
+    def effective_rsa_key_file(self) -> Path:
+        """Path to RSA private key file."""
+        if self.rsa_key_file:
+            return Path(self.rsa_key_file)
+        return self.data_dir / "jwt_rsa_private.pem"
+```
+
+### Step 5: Run tests
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_rsa_keys.py -v
+```
+Expected: All tests pass.
+
+### Step 6: Commit
+
+```bash
+git add apps/backend/app/auth/keys.py apps/backend/app/config.py apps/backend/tests/unit/test_rsa_keys.py
+git commit -m "feat(m5): add RSA key management module for RS256 JWT signing"
+```
+
+---
+
+## Task 2: RS256 JWT Migration
+
+**Files:**
+- Modify: `apps/backend/app/auth/jwt.py`
+- Modify: `apps/backend/app/auth/dependencies.py`
+- Modify: `apps/backend/app/routers/oauth.py`
+- Modify: `apps/backend/app/main.py` (lifespan)
+- Modify: `apps/backend/tests/conftest.py`
+- Create: `apps/backend/tests/unit/test_jwt_rs256.py`
+
+### Step 1: Write tests for RS256 JWT
+
+Create `apps/backend/tests/unit/test_jwt_rs256.py`:
+
+```python
+"""Tests for RS256 JWT token creation and verification."""
+
+import time
+
+import pytest
+
+from app.auth.jwt import create_access_token, verify_access_token
+from app.auth.keys import load_rsa_keys, reset_keys
+
+
+@pytest.fixture(autouse=True)
+def _rsa_keys():
+    reset_keys()
+    load_rsa_keys()
+    yield
+    reset_keys()
+
+
+class TestRS256Tokens:
+    def test_create_and_verify_roundtrip(self):
+        token = create_access_token(user_id="user-123", email="test@example.com")
+        claims = verify_access_token(token)
+        assert claims["sub"] == "user-123"
+        assert claims["email"] == "test@example.com"
+        assert claims["iss"] == "resume-matcher"
+
+    def test_token_contains_kid_header(self):
+        from joserfc import jwt as jose_jwt
+        from app.auth.keys import get_kid, get_public_key
+
+        token = create_access_token(user_id="u1", email="e@x.com")
+        # Decode without verification to inspect header
+        obj = jose_jwt.decode(token, get_public_key())
+        assert obj.header.get("kid") == get_kid()
+        assert obj.header.get("alg") == "RS256"
+
+    def test_expired_token_rejected(self):
+        token = create_access_token(user_id="u1", email="e@x.com", expires_minutes=-1)
+        with pytest.raises(ValueError, match="expired"):
+            verify_access_token(token)
+
+    def test_wrong_key_rejected(self):
+        from joserfc.jwk import RSAKey
+        token = create_access_token(user_id="u1", email="e@x.com")
+        # Verify with a different key should fail
+        other_key = RSAKey.generate_key(2048)
+        reset_keys()
+        load_rsa_keys(pem_data=other_key.as_pem(private=True))
+        with pytest.raises(ValueError, match="invalid"):
+            verify_access_token(token)
+
+    def test_tampered_token_rejected(self):
+        token = create_access_token(user_id="u1", email="e@x.com")
+        # Tamper with the token
+        parts = token.split(".")
+        parts[1] = parts[1][:-4] + "XXXX"
+        tampered = ".".join(parts)
+        with pytest.raises(ValueError):
+            verify_access_token(tampered)
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_jwt_rs256.py -v
+```
+Expected: FAIL -- `create_access_token` still expects `secret` parameter.
+
+### Step 3: Update jwt.py for RS256
+
+Replace the entire content of `apps/backend/app/auth/jwt.py`:
+
+```python
+"""JWT access token operations using joserfc (RS256)."""
+
+import time
+
+from joserfc import jwt
+from joserfc.jwk import RSAKey
+
+from app.auth.constants import ACCESS_TOKEN_EXPIRE_MINUTES
+from app.auth.keys import get_kid, get_private_key, get_public_key
+
+_ALGORITHM = "RS256"
+_ISSUER = "resume-matcher"
+
+
+def create_access_token(
+    user_id: str,
+    email: str,
+    expires_minutes: int = ACCESS_TOKEN_EXPIRE_MINUTES,
+) -> str:
+    """Create an RS256-signed JWT access token."""
+    now = int(time.time())
+    claims = {
+        "sub": user_id,
+        "email": email,
+        "iss": _ISSUER,
+        "iat": now,
+        "exp": now + (expires_minutes * 60),
+    }
+    key = get_private_key()
+    return jwt.encode({"alg": _ALGORITHM, "kid": get_kid()}, claims, key)
+
+
+def verify_access_token(token: str) -> dict:
+    """Verify and decode an RS256 JWT access token. Raises ValueError on failure."""
+    key = get_public_key()
+    try:
+        decoded = jwt.decode(token, key)
+    except Exception as e:
+        raise ValueError(f"Token invalid: {e}") from e
+
+    claims = decoded.claims
+    now = int(time.time())
+    if claims.get("exp", 0) < now:
+        raise ValueError("Token expired")
+    if claims.get("iss") != _ISSUER:
+        raise ValueError("Token invalid: wrong issuer")
+    return claims
+```
+
+### Step 4: Update dependencies.py
+
+In `apps/backend/app/auth/dependencies.py`, remove the `secret` parameter from `verify_access_token` calls:
+
+Replace line 25-27:
+```python
+        claims = verify_access_token(
+            credentials.credentials, secret=settings.effective_jwt_secret
+        )
+```
+With:
+```python
+        claims = verify_access_token(credentials.credentials)
+```
+
+And replace line 52-54 (in `get_optional_user`):
+```python
+        claims = verify_access_token(
+            credentials.credentials, secret=settings.effective_jwt_secret
+        )
+```
+With:
+```python
+        claims = verify_access_token(credentials.credentials)
+```
+
+Remove the `from app.config import settings` import if it's no longer used (check if anything else uses it in that file -- it should now be unused).
+
+### Step 5: Update oauth.py `_issue_tokens`
+
+In `apps/backend/app/routers/oauth.py`, update `_issue_tokens` (around line 170):
+
+Replace:
+```python
+    access_token = create_access_token(
+        user_id=user["id"],
+        email=user["email"],
+        secret=settings.effective_jwt_secret,
+    )
+```
+With:
+```python
+    access_token = create_access_token(
+        user_id=user["id"],
+        email=user["email"],
+    )
+```
+
+Remove `settings` from the import line if it's no longer used by any other code in oauth.py. Check first -- `settings.frontend_origin` is used in `_allowed_redirect_uris()`, so keep the import.
+
+### Step 6: Update main.py lifespan to load RSA keys
+
+In `apps/backend/app/main.py`, add the key loading to the lifespan function.
+
+Add import at top (around line 7):
+```python
+from app.auth.keys import load_rsa_keys
+```
+
+In the `lifespan` function (around line 35), add key loading after db init:
+```python
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Application lifespan manager."""
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    await db.init()
+    load_rsa_keys(
+        pem_data=settings.rsa_private_key_pem or None,
+        key_file=settings.effective_rsa_key_file,
+    )
+    yield
+    # ... existing cleanup ...
+```
+
+### Step 7: Update test fixtures
+
+In `apps/backend/tests/conftest.py`, add the `rsa_keys` fixture and update dependent fixtures.
+
+Add import at top:
+```python
+from app.auth.keys import load_rsa_keys, reset_keys
+```
+
+Add `rsa_keys` fixture (after the `jwt_secret` fixture):
+```python
+@pytest.fixture
+def rsa_keys():
+    """Generate and load test RSA keys for JWT signing."""
+    from joserfc.jwk import RSAKey
+    reset_keys()
+    key = RSAKey.generate_key(2048)
+    load_rsa_keys(pem_data=key.as_pem(private=True))
+    yield
+    reset_keys()
+```
+
+Update `auth_user_a` -- change dependency from `jwt_secret` to `rsa_keys`, remove `secret` parameter:
+```python
+@pytest.fixture
+async def auth_user_a(test_db, rsa_keys):
+    """Create user A and return (user_dict, bearer_token)."""
+    user = await test_db.create_user(email="alice@test.com", hashed_password="hash_a", display_name="Alice")
+    token = create_access_token(user_id=user["id"], email=user["email"])
+    return user, token
+```
+
+Update `auth_user_b` the same way:
+```python
+@pytest.fixture
+async def auth_user_b(test_db, rsa_keys):
+    """Create user B and return (user_dict, bearer_token)."""
+    user = await test_db.create_user(email="bob@test.com", hashed_password="hash_b", display_name="Bob")
+    token = create_access_token(user_id=user["id"], email=user["email"])
+    return user, token
+```
+
+Update `client` fixture -- add `rsa_keys` dependency:
+```python
+@pytest.fixture
+async def client(test_db, jwt_secret, rsa_keys, monkeypatch):
+```
+The `jwt_secret` stays because Google OAuth tests need HMAC; `rsa_keys` is needed for JWT operations.
+
+### Step 8: Run ALL tests
+
+```bash
+cd apps/backend && uv run pytest -x -v
+```
+Expected: All ~296 tests pass. If any tests still pass `secret=` to `create_access_token`, fix them.
+
+### Step 9: Commit
+
+```bash
+git add -A
+git commit -m "feat(m5): migrate JWT signing from HS256 to RS256
+
+Replaces symmetric HS256 signing with asymmetric RS256 key pair.
+RSA keys auto-generated on first startup, persisted to data/jwt_rsa_private.pem.
+HMAC operations (Google OAuth state packing) continue using jwt_secret_key."
+```
+
+---
+
+## Task 3: JWKS + RFC 9728 Metadata Endpoints
+
+**Files:**
+- Modify: `apps/backend/app/main.py`
+- Create: `apps/backend/tests/integration/test_well_known_endpoints.py`
+
+### Step 1: Write tests
+
+Create `apps/backend/tests/integration/test_well_known_endpoints.py`:
+
+```python
+"""Tests for .well-known metadata endpoints."""
+
+import pytest
+
+
+class TestJWKS:
+    @pytest.mark.anyio
+    async def test_jwks_returns_public_key(self, client):
+        resp = await client.get("/.well-known/jwks.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "keys" in data
+        assert len(data["keys"]) == 1
+        key = data["keys"][0]
+        assert key["kty"] == "RSA"
+        assert key["alg"] == "RS256"
+        assert key["use"] == "sig"
+        assert "kid" in key
+        assert "n" in key
+        assert "e" in key
+        # Must not expose private key
+        assert "d" not in key
+        assert "p" not in key
+
+    @pytest.mark.anyio
+    async def test_jwks_kid_matches_token_kid(self, client, auth_headers_a):
+        """JWKS kid should match the kid in issued tokens."""
+        import base64, json
+        jwks = (await client.get("/.well-known/jwks.json")).json()
+        jwks_kid = jwks["keys"][0]["kid"]
+
+        # Get a token by checking its header
+        _, token = (await client.get("/api/v1/auth/me", headers=auth_headers_a)), None
+        # Actually use the token from auth_headers_a
+        token_str = auth_headers_a["Authorization"].split(" ")[1]
+        header_b64 = token_str.split(".")[0]
+        # Add padding
+        header_b64 += "=" * (4 - len(header_b64) % 4)
+        header = json.loads(base64.urlsafe_b64decode(header_b64))
+        assert header["kid"] == jwks_kid
+
+
+class TestProtectedResourceMetadata:
+    @pytest.mark.anyio
+    async def test_returns_required_fields(self, client):
+        resp = await client.get("/.well-known/oauth-protected-resource")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "resource" in data
+        assert "authorization_servers" in data
+        assert isinstance(data["authorization_servers"], list)
+        assert len(data["authorization_servers"]) >= 1
+        assert data["bearer_methods_supported"] == ["header"]
+
+    @pytest.mark.anyio
+    async def test_resource_matches_base_url(self, client):
+        resp = await client.get("/.well-known/oauth-protected-resource")
+        data = resp.json()
+        assert data["resource"] == "http://test"
+
+    @pytest.mark.anyio
+    async def test_authorization_server_is_self(self, client):
+        resp = await client.get("/.well-known/oauth-protected-resource")
+        data = resp.json()
+        assert data["authorization_servers"][0] == "http://test"
+
+
+class TestOAuthServerMetadata:
+    @pytest.mark.anyio
+    async def test_includes_registration_endpoint(self, client):
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        data = resp.json()
+        assert data["registration_endpoint"] is not None
+        assert "register" in data["registration_endpoint"]
+
+    @pytest.mark.anyio
+    async def test_includes_jwks_uri(self, client):
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        data = resp.json()
+        assert data["jwks_uri"] is not None
+        assert "jwks" in data["jwks_uri"]
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_well_known_endpoints.py -v
+```
+Expected: FAIL -- endpoints don't exist yet.
+
+### Step 3: Add endpoints to main.py
+
+In `apps/backend/app/main.py`, add the import:
+```python
+from app.auth.keys import get_jwks
+```
+
+Add after the existing `/.well-known/oauth-authorization-server` endpoint (after line 102):
+
+```python
+@app.get("/.well-known/jwks.json")
+async def jwks_endpoint() -> dict:
+    """RFC 7517 JSON Web Key Set -- public key for token verification."""
+    return get_jwks()
+
+
+@app.get("/.well-known/oauth-protected-resource")
+async def protected_resource_metadata(request: Request) -> dict:
+    """RFC 9728 OAuth 2.0 Protected Resource Metadata."""
+    base = str(request.base_url).rstrip("/")
+    return {
+        "resource": base,
+        "authorization_servers": [base],
+        "bearer_methods_supported": ["header"],
+        "resource_name": "Resume Matcher",
+    }
+```
+
+Update the existing RFC 8414 metadata to include `registration_endpoint` and `jwks_uri`:
+```python
+@app.get("/.well-known/oauth-authorization-server")
+async def oauth_server_metadata(request: Request) -> dict:
+    """RFC 8414 OAuth 2.1 Authorization Server Metadata."""
+    base = str(request.base_url).rstrip("/")
+    api_base = f"{base}/api/v1"
+    return {
+        "issuer": base,
+        "authorization_endpoint": f"{api_base}/oauth/authorize",
+        "token_endpoint": f"{api_base}/oauth/token",
+        "revocation_endpoint": f"{api_base}/oauth/revoke",
+        "registration_endpoint": f"{api_base}/oauth/register",
+        "jwks_uri": f"{base}/.well-known/jwks.json",
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "refresh_token"],
+        "code_challenge_methods_supported": ["S256"],
+        "token_endpoint_auth_methods_supported": ["none"],
+        "scopes_supported": ["openid", "profile", "email"],
+    }
+```
+
+### Step 4: Run tests
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_well_known_endpoints.py -v
+```
+Expected: All pass.
+
+### Step 5: Commit
+
+```bash
+git add -A
+git commit -m "feat(m5): add JWKS, RFC 9728, and update RFC 8414 metadata endpoints"
+```
+
+---
+
+## Task 4: OAuthClient Model + Alembic Migration
+
+**Files:**
+- Modify: `apps/backend/app/models.py`
+- Create: `apps/backend/alembic/versions/<hash>_add_oauth_clients_table.py`
+- Modify: `apps/backend/app/database.py`
+- Create: `apps/backend/tests/unit/test_oauth_clients_db.py`
+
+### Step 1: Write tests for OAuthClient DB operations
+
+Create `apps/backend/tests/unit/test_oauth_clients_db.py`:
+
+```python
+"""Tests for OAuthClient database operations."""
+
+import pytest
+
+
+class TestOAuthClientCRUD:
+    @pytest.mark.anyio
+    async def test_create_oauth_client(self, test_db):
+        client = await test_db.create_oauth_client(
+            client_name="Test App",
+            redirect_uris=["http://localhost:3000/callback"],
+        )
+        assert client["client_id"] is not None
+        assert client["client_name"] == "Test App"
+        assert client["redirect_uris"] == ["http://localhost:3000/callback"]
+        assert client["token_endpoint_auth_method"] == "none"
+        assert client["is_active"] is True
+
+    @pytest.mark.anyio
+    async def test_get_oauth_client(self, test_db):
+        created = await test_db.create_oauth_client(
+            client_name="App",
+            redirect_uris=["http://example.com/cb"],
+        )
+        fetched = await test_db.get_oauth_client(created["client_id"])
+        assert fetched is not None
+        assert fetched["client_id"] == created["client_id"]
+
+    @pytest.mark.anyio
+    async def test_get_nonexistent_client_returns_none(self, test_db):
+        result = await test_db.get_oauth_client("nonexistent-id")
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_create_client_with_custom_fields(self, test_db):
+        client = await test_db.create_oauth_client(
+            client_name="Claude",
+            redirect_uris=["https://claude.ai/api/mcp/auth_callback"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+        assert client["grant_types"] == ["authorization_code", "refresh_token"]
+        assert client["response_types"] == ["code"]
+
+    @pytest.mark.anyio
+    async def test_create_client_with_explicit_id(self, test_db):
+        """Used for seeding the first-party client."""
+        client = await test_db.create_oauth_client(
+            client_id="resume-matcher-web",
+            client_name="Resume Matcher Web",
+            redirect_uris=["http://localhost:3000/callback"],
+        )
+        assert client["client_id"] == "resume-matcher-web"
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_oauth_clients_db.py -v
+```
+Expected: FAIL -- `create_oauth_client` method does not exist.
+
+### Step 3: Add OAuthClient model
+
+In `apps/backend/app/models.py`, add after the `OAuthAccount` class (before the end of the file):
+
+```python
+class OAuthClient(Base):
+    """Dynamically registered OAuth clients (RFC 7591)."""
+    __tablename__ = "oauth_clients"
+    client_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    client_name: Mapped[str | None] = mapped_column(String(255))
+    redirect_uris: Mapped[list] = mapped_column(JSON, default=list)
+    grant_types: Mapped[list] = mapped_column(JSON, default=lambda: ["authorization_code"])
+    response_types: Mapped[list] = mapped_column(JSON, default=lambda: ["code"])
+    token_endpoint_auth_method: Mapped[str] = mapped_column(String(50), default="none")
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+```
+
+Add `OAuthClient` to the import in `apps/backend/app/database.py` (line 13):
+```python
+from app.models import AuthorizationCode, Base, Improvement, Job, OAuthAccount, OAuthClient, RefreshToken, Resume, User
+```
+
+### Step 4: Add DB CRUD methods
+
+In `apps/backend/app/database.py`, add after the OAuth account operations section:
+
+```python
+    # -- OAuth client operations ------------------------------------------------
+
+    @staticmethod
+    def _oauth_client_to_dict(c: OAuthClient) -> dict[str, Any]:
+        return {
+            "client_id": c.client_id,
+            "client_name": c.client_name,
+            "redirect_uris": c.redirect_uris or [],
+            "grant_types": c.grant_types or ["authorization_code"],
+            "response_types": c.response_types or ["code"],
+            "token_endpoint_auth_method": c.token_endpoint_auth_method or "none",
+            "is_active": c.is_active,
+            "created_at": c.created_at.isoformat() if c.created_at else None,
+        }
+
+    async def create_oauth_client(
+        self,
+        client_name: str | None = None,
+        redirect_uris: list[str] | None = None,
+        grant_types: list[str] | None = None,
+        response_types: list[str] | None = None,
+        token_endpoint_auth_method: str = "none",
+        client_id: str | None = None,
+    ) -> dict[str, Any]:
+        client = OAuthClient(
+            client_id=client_id or str(uuid4()),
+            client_name=client_name,
+            redirect_uris=redirect_uris or [],
+            grant_types=grant_types or ["authorization_code"],
+            response_types=response_types or ["code"],
+            token_endpoint_auth_method=token_endpoint_auth_method,
+        )
+        async with self._session() as session:
+            session.add(client)
+            await session.commit()
+            await session.refresh(client)
+            return self._oauth_client_to_dict(client)
+
+    async def get_oauth_client(self, client_id: str) -> dict[str, Any] | None:
+        async with self._session() as session:
+            result = await session.execute(
+                select(OAuthClient).where(OAuthClient.client_id == client_id)
+            )
+            row = result.scalar_one_or_none()
+            return self._oauth_client_to_dict(row) if row else None
+```
+
+### Step 5: Create Alembic migration
+
+Run:
+```bash
+cd apps/backend && uv run alembic revision --autogenerate -m "add oauth_clients table"
+```
+
+Then edit the generated migration to add first-party client seed. The migration should look like:
+
+```python
+"""add oauth_clients table
+
+Revision ID: <auto-generated>
+Revises: a1b2c3d4e5f6
+"""
+from typing import Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '<auto-generated>'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'oauth_clients',
+        sa.Column('client_id', sa.String(255), primary_key=True),
+        sa.Column('client_name', sa.String(255), nullable=True),
+        sa.Column('redirect_uris', sa.JSON(), nullable=False, server_default='[]'),
+        sa.Column('grant_types', sa.JSON(), nullable=False, server_default='["authorization_code"]'),
+        sa.Column('response_types', sa.JSON(), nullable=False, server_default='["code"]'),
+        sa.Column('token_endpoint_auth_method', sa.String(50), nullable=False, server_default='none'),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('1')),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+    # Seed first-party client
+    op.execute(
+        sa.text(
+            "INSERT INTO oauth_clients (client_id, client_name, redirect_uris, grant_types, response_types, token_endpoint_auth_method, is_active) "
+            "VALUES (:cid, :name, :uris, :grants, :types, :method, 1)"
+        ).bindparams(
+            cid="resume-matcher-web",
+            name="Resume Matcher Web",
+            uris='["http://localhost:3000/callback", "http://127.0.0.1:3000/callback"]',
+            grants='["authorization_code", "refresh_token"]',
+            types='["code"]',
+            method="none",
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('oauth_clients')
+```
+
+### Step 6: Run tests
+
+```bash
+cd apps/backend && uv run pytest tests/unit/test_oauth_clients_db.py -v
+```
+Expected: All pass.
+
+### Step 7: Commit
+
+```bash
+git add -A
+git commit -m "feat(m5): add OAuthClient model, migration, and DB operations for DCR"
+```
+
+---
+
+## Task 5: Dynamic Client Registration + DB Client Validation
+
+**Files:**
+- Modify: `apps/backend/app/schemas/auth.py`
+- Modify: `apps/backend/app/routers/oauth.py`
+- Create: `apps/backend/tests/integration/test_dcr.py`
+
+### Step 1: Write tests
+
+Create `apps/backend/tests/integration/test_dcr.py`:
+
+```python
+"""Tests for Dynamic Client Registration (RFC 7591)."""
+
+import pytest
+
+
+class TestDCR:
+    @pytest.mark.anyio
+    async def test_register_new_client(self, client):
+        resp = await client.post("/api/v1/oauth/register", json={
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+            "client_name": "Claude",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "client_id" in data
+        assert data["client_name"] == "Claude"
+        assert data["redirect_uris"] == ["https://claude.ai/api/mcp/auth_callback"]
+        assert data["token_endpoint_auth_method"] == "none"
+        assert "client_id_issued_at" in data
+
+    @pytest.mark.anyio
+    async def test_register_without_redirect_uris_fails(self, client):
+        resp = await client.post("/api/v1/oauth/register", json={
+            "client_name": "Bad Client",
+        })
+        assert resp.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_register_defaults_auth_method_to_none(self, client):
+        """claude.ai omits token_endpoint_auth_method -- must default to 'none'."""
+        resp = await client.post("/api/v1/oauth/register", json={
+            "redirect_uris": ["https://example.com/callback"],
+        })
+        assert resp.status_code == 201
+        assert resp.json()["token_endpoint_auth_method"] == "none"
+
+    @pytest.mark.anyio
+    async def test_registered_client_can_authorize(self, client, test_db, rsa_keys, jwt_secret):
+        """Full flow: register -> create user -> authorize -> token."""
+        # Register client
+        reg = await client.post("/api/v1/oauth/register", json={
+            "redirect_uris": ["http://localhost:9999/callback"],
+            "client_name": "Test MCP Client",
+        })
+        assert reg.status_code == 201
+        client_id = reg.json()["client_id"]
+
+        # Create a user
+        await client.post("/api/v1/auth/register", json={
+            "email": "dcr@test.com",
+            "password": "testpassword123",
+            "display_name": "DCR User",
+        })
+
+        # Authorize with the DCR client
+        from app.auth.pkce import verify_code_challenge
+        import hashlib, base64, secrets
+        code_verifier = secrets.token_urlsafe(32)
+        code_challenge = base64.urlsafe_b64encode(
+            hashlib.sha256(code_verifier.encode()).digest()
+        ).rstrip(b"=").decode()
+
+        auth_resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "dcr@test.com",
+            "password": "testpassword123",
+            "client_id": client_id,
+            "redirect_uri": "http://localhost:9999/callback",
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }, follow_redirects=False)
+        assert auth_resp.status_code == 303
+
+        # Extract code from redirect
+        from urllib.parse import urlparse, parse_qs
+        redirect_url = auth_resp.headers["location"]
+        code = parse_qs(urlparse(redirect_url).query)["code"][0]
+
+        # Exchange for token
+        token_resp = await client.post("/api/v1/oauth/token", json={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": code_verifier,
+            "client_id": client_id,
+            "redirect_uri": "http://localhost:9999/callback",
+        })
+        assert token_resp.status_code == 200
+        assert "access_token" in token_resp.json()
+
+
+class TestDBClientValidation:
+    @pytest.mark.anyio
+    async def test_first_party_client_works(self, client, test_db, rsa_keys, jwt_secret):
+        """Seeded first-party client should work with authorize."""
+        # Seed the first-party client (normally done by migration)
+        await test_db.create_oauth_client(
+            client_id="resume-matcher-web",
+            client_name="Resume Matcher Web",
+            redirect_uris=["http://localhost:3000/callback"],
+        )
+        await client.post("/api/v1/auth/register", json={
+            "email": "fp@test.com",
+            "password": "testpassword123",
+        })
+
+        import hashlib, base64, secrets
+        cv = secrets.token_urlsafe(32)
+        cc = base64.urlsafe_b64encode(hashlib.sha256(cv.encode()).digest()).rstrip(b"=").decode()
+
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "fp@test.com",
+            "password": "testpassword123",
+            "client_id": "resume-matcher-web",
+            "redirect_uri": "http://localhost:3000/callback",
+            "code_challenge": cc,
+        }, follow_redirects=False)
+        assert resp.status_code == 303
+
+    @pytest.mark.anyio
+    async def test_unknown_client_rejected(self, client):
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "x@test.com",
+            "password": "pass",
+            "client_id": "unknown-client",
+            "redirect_uri": "http://evil.com/callback",
+            "code_challenge": "abc",
+        })
+        assert resp.status_code == 400
+        assert "Unknown client_id" in resp.json()["detail"]
+
+    @pytest.mark.anyio
+    async def test_wrong_redirect_uri_rejected(self, client, test_db):
+        await test_db.create_oauth_client(
+            client_id="test-client",
+            redirect_uris=["http://legit.com/callback"],
+        )
+        resp = await client.post("/api/v1/oauth/authorize", json={
+            "email": "x@test.com",
+            "password": "pass",
+            "client_id": "test-client",
+            "redirect_uri": "http://evil.com/callback",
+            "code_challenge": "abc",
+        })
+        assert resp.status_code == 400
+        assert "redirect_uri" in resp.json()["detail"].lower()
+```
+
+### Step 2: Run tests to verify they fail
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_dcr.py -v
+```
+
+### Step 3: Add Pydantic schemas
+
+In `apps/backend/app/schemas/auth.py`, add:
+
+```python
+class ClientRegistrationRequest(BaseModel):
+    """RFC 7591 Dynamic Client Registration request."""
+    redirect_uris: list[str] = Field(min_length=1)
+    client_name: str | None = None
+    token_endpoint_auth_method: str = "none"
+    grant_types: list[str] = Field(default=["authorization_code"])
+    response_types: list[str] = Field(default=["code"])
+
+
+class ClientRegistrationResponse(BaseModel):
+    """RFC 7591 Dynamic Client Registration response."""
+    client_id: str
+    client_name: str | None
+    redirect_uris: list[str]
+    grant_types: list[str]
+    response_types: list[str]
+    token_endpoint_auth_method: str
+    client_id_issued_at: int
+```
+
+### Step 4: Add DCR endpoint and update client validation
+
+In `apps/backend/app/routers/oauth.py`:
+
+Add imports:
+```python
+from app.schemas.auth import ClientRegistrationRequest, ClientRegistrationResponse
+```
+
+Replace `_validate_client` (synchronous) with async DB-based validation:
+```python
+async def _validate_client(client_id: str, redirect_uri: str) -> None:
+    """Validate client_id and redirect_uri against registered clients."""
+    oauth_client = await db.get_oauth_client(client_id)
+    if not oauth_client or not oauth_client["is_active"]:
+        raise HTTPException(status_code=400, detail="Unknown client_id")
+
+    allowed = list(oauth_client["redirect_uris"])
+    # First-party client also accepts dynamic frontend origin
+    if client_id == FIRST_PARTY_CLIENT_ID:
+        dynamic = f"{settings.frontend_origin.rstrip('/')}/callback"
+        if dynamic not in allowed:
+            allowed.append(dynamic)
+
+    if redirect_uri not in allowed:
+        raise HTTPException(status_code=400, detail="Invalid redirect_uri")
+```
+
+Update `authorize` endpoint to use `await _validate_client(...)`:
+```python
+@router.post("/authorize")
+async def authorize(body: AuthorizeRequest) -> Response:
+    await _validate_client(body.client_id, body.redirect_uri)
+    # ... rest unchanged
+```
+
+Also update the token exchange to use async validation (in `_handle_code_exchange`, around line 125):
+```python
+    # Validate client_id matches
+    oauth_client = await db.get_oauth_client(body.client_id)
+    if not oauth_client or stored["client_id"] != body.client_id or stored["redirect_uri"] != body.redirect_uri:
+        raise HTTPException(status_code=400, detail="Client/redirect mismatch")
+```
+
+Remove `_allowed_redirect_uris()` function (no longer needed for OAuth authorize -- still needed by `google_oauth.py` though, so check before removing. If google_oauth imports it, keep it or move to a shared location).
+
+Add the DCR endpoint:
+```python
+@router.post("/register", response_model=ClientRegistrationResponse, status_code=201)
+async def register_client(body: ClientRegistrationRequest) -> ClientRegistrationResponse:
+    """RFC 7591 Dynamic Client Registration."""
+    import time
+
+    client = await db.create_oauth_client(
+        client_name=body.client_name,
+        redirect_uris=body.redirect_uris,
+        grant_types=body.grant_types,
+        response_types=body.response_types,
+        token_endpoint_auth_method=body.token_endpoint_auth_method,
+    )
+
+    return ClientRegistrationResponse(
+        client_id=client["client_id"],
+        client_name=client["client_name"],
+        redirect_uris=client["redirect_uris"],
+        grant_types=client["grant_types"],
+        response_types=client["response_types"],
+        token_endpoint_auth_method=client["token_endpoint_auth_method"],
+        client_id_issued_at=int(time.time()),
+    )
+```
+
+### Step 5: Fix existing tests
+
+Existing OAuth tests that use `client_id="resume-matcher-web"` will need the first-party client seeded in the DB. Update relevant test fixtures or add a helper that seeds it. The simplest approach: add a `seed_first_party_client` fixture:
+
+In `apps/backend/tests/conftest.py`:
+```python
+@pytest.fixture
+async def first_party_client(test_db):
+    """Seed the first-party OAuth client (normally done by migration)."""
+    await test_db.create_oauth_client(
+        client_id="resume-matcher-web",
+        client_name="Resume Matcher Web",
+        redirect_uris=[
+            "http://localhost:3000/callback",
+            "http://127.0.0.1:3000/callback",
+        ],
+        grant_types=["authorization_code", "refresh_token"],
+    )
+```
+
+Add `first_party_client` as a dependency to tests that use the OAuth authorize/token flow.
+
+### Step 6: Run tests
+
+```bash
+cd apps/backend && uv run pytest -x -v
+```
+Expected: All pass.
+
+### Step 7: Commit
+
+```bash
+git add -A
+git commit -m "feat(m5): add Dynamic Client Registration (RFC 7591) and DB-based client validation"
+```
+
+---
+
+## Task 6: claude.ai Compatibility Endpoints
+
+**Files:**
+- Modify: `apps/backend/app/main.py`
+- Create: `apps/backend/tests/integration/test_claude_compat.py`
+
+### Step 1: Write tests
+
+Create `apps/backend/tests/integration/test_claude_compat.py`:
+
+```python
+"""Tests for claude.ai compatibility proxy endpoints.
+
+claude.ai web ignores AS metadata URLs and appends /authorize, /token,
+/register to the server root. These proxy endpoints handle that.
+"""
+
+import pytest
+
+
+class TestClaudeCompat:
+    @pytest.mark.anyio
+    async def test_root_register_proxies_to_api(self, client):
+        """POST /register should work like POST /api/v1/oauth/register."""
+        resp = await client.post("/register", json={
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+            "client_name": "Claude via root",
+        })
+        assert resp.status_code == 201
+        assert "client_id" in resp.json()
+
+    @pytest.mark.anyio
+    async def test_root_authorize_redirects(self, client):
+        """GET /authorize should redirect to /api/v1/oauth/authorize."""
+        resp = await client.get(
+            "/authorize",
+            params={"response_type": "code", "client_id": "test"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 307
+        assert "/api/v1/oauth/authorize" in resp.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_root_token_proxies_to_api(self, client, test_db):
+        """POST /token should work like POST /api/v1/oauth/token."""
+        resp = await client.post("/token", json={
+            "grant_type": "authorization_code",
+            "code": "invalid",
+            "code_verifier": "test",
+            "client_id": "test",
+            "redirect_uri": "http://localhost/callback",
+        })
+        # Should reach the real token endpoint (400 because code is invalid, not 404)
+        assert resp.status_code == 400
+```
+
+### Step 2: Add proxy endpoints to main.py
+
+In `apps/backend/app/main.py`, add after the well-known endpoints:
+
+```python
+# -- claude.ai compatibility proxies ------------------------------------------
+# claude.ai web appends /authorize, /token, /register to the server root,
+# ignoring the URLs in AS metadata. These thin proxies handle that quirk.
+
+@app.api_route("/register", methods=["POST"])
+async def root_register(request: Request):
+    """Proxy POST /register -> POST /api/v1/oauth/register."""
+    from app.schemas.auth import ClientRegistrationRequest
+    body = await request.json()
+    from app.routers.oauth import register_client
+    return await register_client(ClientRegistrationRequest(**body))
+
+
+@app.get("/authorize")
+async def root_authorize(request: Request):
+    """Redirect GET /authorize -> GET /api/v1/oauth/authorize with query params."""
+    qs = str(request.query_params)
+    target = f"/api/v1/oauth/authorize"
+    if qs:
+        target = f"{target}?{qs}"
+    return RedirectResponse(url=target, status_code=307)
+
+
+@app.api_route("/token", methods=["POST"])
+async def root_token(request: Request):
+    """Proxy POST /token -> POST /api/v1/oauth/token."""
+    from app.schemas.auth import TokenRequest
+    body = await request.json()
+    from app.routers.oauth import token as token_endpoint
+    return await token_endpoint(TokenRequest(**body), request, Response())
+```
+
+Note: The token proxy needs to handle the Response for cookie setting. This may need refinement -- the simplest approach is to forward the request using `httpx` or just call the handler directly. Test and adjust.
+
+### Step 3: Run tests
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_claude_compat.py -v
+```
+
+### Step 4: Commit
+
+```bash
+git add -A
+git commit -m "feat(m5): add root-level proxy endpoints for claude.ai web compatibility"
+```
+
+---
+
+## Task 7: MCP Endpoint with Tools
+
+**Files:**
+- Create: `apps/backend/app/routers/mcp.py`
+- Modify: `apps/backend/app/routers/__init__.py`
+- Modify: `apps/backend/app/main.py`
+- Create: `apps/backend/tests/integration/test_mcp.py`
+
+### Step 1: Write tests
+
+Create `apps/backend/tests/integration/test_mcp.py`:
+
+```python
+"""Tests for MCP endpoint (JSON-RPC 2.0 over Streamable HTTP)."""
+
+import pytest
+
+
+def _jsonrpc(method: str, params: dict | None = None, msg_id: int = 1) -> dict:
+    msg = {"jsonrpc": "2.0", "method": method, "id": msg_id}
+    if params:
+        msg["params"] = params
+    return msg
+
+
+class TestMCPInitialize:
+    @pytest.mark.anyio
+    async def test_initialize_without_auth(self, client):
+        """initialize must work without Bearer token."""
+        resp = await client.post("/mcp", json=_jsonrpc("initialize", {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"},
+        }))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "result" in data
+        result = data["result"]
+        assert "serverInfo" in result
+        assert "capabilities" in result
+        assert result["capabilities"].get("tools") is not None
+
+    @pytest.mark.anyio
+    async def test_initialize_returns_session_id(self, client):
+        resp = await client.post("/mcp", json=_jsonrpc("initialize", {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"},
+        }))
+        assert "mcp-session-id" in resp.headers
+
+
+class TestMCPAuth:
+    @pytest.mark.anyio
+    async def test_tools_list_requires_auth(self, client):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/list"))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "error" in data
+        assert data["error"]["code"] == -32600
+
+    @pytest.mark.anyio
+    async def test_tools_list_with_auth(self, client, auth_headers_a):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/list"), headers=auth_headers_a)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "result" in data
+        tools = data["result"]["tools"]
+        assert len(tools) > 0
+        tool_names = [t["name"] for t in tools]
+        assert "list_resumes" in tool_names
+
+
+class TestMCPToolCalls:
+    @pytest.mark.anyio
+    async def test_list_resumes_empty(self, client, auth_headers_a):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "list_resumes",
+            "arguments": {},
+        }), headers=auth_headers_a)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "result" in data
+        # Result content should be a text block with empty list
+        content = data["result"]["content"]
+        assert isinstance(content, list)
+
+    @pytest.mark.anyio
+    async def test_list_resumes_returns_user_data(self, client, auth_headers_a, auth_user_a, test_db, sample_resume):
+        """List resumes should return only the authenticated user's resumes."""
+        import json
+        user_a, _ = auth_user_a
+        await test_db.create_resume(content=json.dumps(sample_resume), user_id=user_a["id"], title="My Resume")
+
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "list_resumes",
+            "arguments": {},
+        }), headers=auth_headers_a)
+        data = resp.json()
+        content = data["result"]["content"]
+        assert len(content) == 1
+        assert "text" in content[0]
+        assert "My Resume" in content[0]["text"]
+
+    @pytest.mark.anyio
+    async def test_tool_call_isolation(self, client, auth_headers_a, auth_headers_b, auth_user_a, auth_user_b, test_db, sample_resume):
+        """User A's data should not be visible to User B via MCP."""
+        import json
+        user_a, _ = auth_user_a
+        await test_db.create_resume(content=json.dumps(sample_resume), user_id=user_a["id"], title="A's Resume")
+
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "list_resumes",
+            "arguments": {},
+        }), headers=auth_headers_b)
+        data = resp.json()
+        content = data["result"]["content"]
+        # User B should see empty list
+        assert "A's Resume" not in str(content)
+
+    @pytest.mark.anyio
+    async def test_unknown_tool_returns_error(self, client, auth_headers_a):
+        resp = await client.post("/mcp", json=_jsonrpc("tools/call", {
+            "name": "nonexistent_tool",
+            "arguments": {},
+        }), headers=auth_headers_a)
+        data = resp.json()
+        assert "error" in data
+```
+
+### Step 2: Implement MCP router
+
+Create `apps/backend/app/routers/mcp.py`:
+
+```python
+"""MCP (Model Context Protocol) endpoint -- JSON-RPC 2.0 over Streamable HTTP."""
+
+import json
+import logging
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+
+from app.auth.jwt import verify_access_token
+from app.database import db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["mcp"])
+
+# Protocol version we support
+_PROTOCOL_VERSION = "2025-06-18"
+_SERVER_NAME = "resume-matcher"
+_SERVER_VERSION = "1.0.0"
+
+
+# -- Tool definitions ---------------------------------------------------------
+
+TOOLS: list[dict[str, Any]] = [
+    {
+        "name": "list_resumes",
+        "description": "List all resumes belonging to the authenticated user.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "get_resume",
+        "description": "Get a specific resume by ID, including its processed content.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "resume_id": {"type": "string", "description": "The resume UUID"},
+            },
+            "required": ["resume_id"],
+        },
+    },
+    {
+        "name": "get_status",
+        "description": "Get dashboard stats: resume count, job count, improvements count.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "upload_job_description",
+        "description": "Upload a job description text. Optionally link to a resume.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "content": {"type": "string", "description": "The job description text"},
+                "resume_id": {"type": "string", "description": "Optional resume ID to link"},
+            },
+            "required": ["content"],
+        },
+    },
+    {
+        "name": "set_master_resume",
+        "description": "Set a resume as the master (source of truth) resume.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "resume_id": {"type": "string", "description": "The resume UUID to set as master"},
+            },
+            "required": ["resume_id"],
+        },
+    },
+]
+
+
+# -- Tool handlers ------------------------------------------------------------
+
+async def _tool_list_resumes(user: dict, _args: dict) -> str:
+    resumes = await db.list_resumes(user["id"])
+    if not resumes:
+        return "No resumes found."
+    lines = []
+    for r in resumes:
+        master = " [MASTER]" if r.get("is_master") else ""
+        title = r.get("title") or r.get("filename") or "Untitled"
+        lines.append(f"- {title} (id: {r['resume_id']}){master}")
+    return "\n".join(lines)
+
+
+async def _tool_get_resume(user: dict, args: dict) -> str:
+    resume_id = args.get("resume_id")
+    if not resume_id:
+        return "Error: resume_id is required"
+    resume = await db.get_resume(resume_id, user["id"])
+    if not resume:
+        return "Resume not found."
+    return json.dumps(resume, indent=2, default=str)
+
+
+async def _tool_get_status(user: dict, _args: dict) -> str:
+    stats = await db.get_stats(user["id"])
+    return json.dumps(stats, indent=2)
+
+
+async def _tool_upload_job(user: dict, args: dict) -> str:
+    content = args.get("content")
+    if not content:
+        return "Error: content is required"
+    resume_id = args.get("resume_id")
+    if resume_id:
+        resume = await db.get_resume(resume_id, user["id"])
+        if not resume:
+            return "Error: resume not found"
+    job = await db.create_job(content=content, user_id=user["id"], resume_id=resume_id)
+    return f"Job created: {job['job_id']}"
+
+
+async def _tool_set_master(user: dict, args: dict) -> str:
+    resume_id = args.get("resume_id")
+    if not resume_id:
+        return "Error: resume_id is required"
+    ok = await db.set_master_resume(resume_id, user["id"])
+    if ok:
+        return f"Resume {resume_id} set as master."
+    return "Error: resume not found."
+
+
+_TOOL_HANDLERS: dict[str, Any] = {
+    "list_resumes": _tool_list_resumes,
+    "get_resume": _tool_get_resume,
+    "get_status": _tool_get_status,
+    "upload_job_description": _tool_upload_job,
+    "set_master_resume": _tool_set_master,
+}
+
+
+# -- JSON-RPC helpers ---------------------------------------------------------
+
+def _jsonrpc_result(msg_id: int | str | None, result: Any) -> dict:
+    return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+
+
+def _jsonrpc_error(msg_id: int | str | None, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
+
+
+# -- Auth helper --------------------------------------------------------------
+
+async def _resolve_user(request: Request) -> dict | None:
+    """Extract Bearer token and resolve user. Returns None if not authenticated."""
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return None
+    token = auth_header[7:]
+    try:
+        claims = verify_access_token(token)
+    except ValueError:
+        return None
+    return await db.get_user_by_id(claims["sub"])
+
+
+# -- Main handler -------------------------------------------------------------
+
+@router.post("/mcp")
+async def mcp_handler(request: Request) -> JSONResponse:
+    """MCP Streamable HTTP endpoint (JSON-RPC 2.0)."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            content=_jsonrpc_error(None, -32700, "Parse error"),
+            status_code=200,
+        )
+
+    # Handle single message (not batch for now)
+    if isinstance(body, list):
+        # Batch not supported yet
+        return JSONResponse(
+            content=_jsonrpc_error(None, -32600, "Batch requests not supported"),
+            status_code=200,
+        )
+
+    method = body.get("method")
+    msg_id = body.get("id")
+    params = body.get("params", {})
+
+    # -- initialize (no auth required) --
+    if method == "initialize":
+        result = {
+            "protocolVersion": _PROTOCOL_VERSION,
+            "serverInfo": {"name": _SERVER_NAME, "version": _SERVER_VERSION},
+            "capabilities": {
+                "tools": {"listChanged": False},
+            },
+        }
+        session_id = str(uuid4())
+        return JSONResponse(
+            content=_jsonrpc_result(msg_id, result),
+            headers={"mcp-session-id": session_id},
+        )
+
+    # -- notifications (no response) --
+    if method == "notifications/initialized":
+        return JSONResponse(content=None, status_code=204)
+
+    # -- Auth required for all other methods --
+    user = await _resolve_user(request)
+    if not user:
+        return JSONResponse(
+            content=_jsonrpc_error(msg_id, -32600, "Unauthorized -- Bearer token required"),
+            status_code=200,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    # -- tools/list --
+    if method == "tools/list":
+        return JSONResponse(content=_jsonrpc_result(msg_id, {"tools": TOOLS}))
+
+    # -- tools/call --
+    if method == "tools/call":
+        tool_name = params.get("name")
+        tool_args = params.get("arguments", {})
+
+        handler = _TOOL_HANDLERS.get(tool_name)
+        if not handler:
+            return JSONResponse(
+                content=_jsonrpc_error(msg_id, -32602, f"Unknown tool: {tool_name}"),
+            )
+
+        try:
+            text_result = await handler(user, tool_args)
+        except Exception as e:
+            logger.error("MCP tool %s failed: %s", tool_name, e, exc_info=True)
+            return JSONResponse(
+                content=_jsonrpc_error(msg_id, -32603, f"Tool execution failed: {e}"),
+            )
+
+        return JSONResponse(content=_jsonrpc_result(msg_id, {
+            "content": [{"type": "text", "text": text_result}],
+        }))
+
+    return JSONResponse(content=_jsonrpc_error(msg_id, -32601, f"Method not found: {method}"))
+```
+
+### Step 3: Register the router
+
+In `apps/backend/app/routers/__init__.py`, add:
+```python
+from app.routers.mcp import router as mcp_router
+```
+And add `"mcp_router"` to `__all__`.
+
+In `apps/backend/app/main.py`, add import and router:
+```python
+from app.routers import ..., mcp_router
+```
+```python
+app.include_router(mcp_router)  # No prefix -- mounted at /mcp directly
+```
+
+Also add `mcp` module to the `client` fixture's DB patching list in `conftest.py`:
+```python
+import app.routers.mcp as mcp_mod
+# Add mcp_mod to the patching loop
+```
+
+### Step 4: Run tests
+
+```bash
+cd apps/backend && uv run pytest tests/integration/test_mcp.py -v
+```
+
+### Step 5: Run full test suite
+
+```bash
+cd apps/backend && uv run pytest -x -v
+```
+
+### Step 6: Commit
+
+```bash
+git add -A
+git commit -m "feat(m5): add MCP endpoint with JSON-RPC handler and tool definitions
+
+Implements MCP Streamable HTTP protocol at /mcp with tools:
+list_resumes, get_resume, get_status, upload_job_description, set_master_resume.
+Auth required for tools/list and tools/call; initialize works without auth."
+```
+
+---
+
+## Post-Implementation Checklist
+
+After all tasks are complete:
+
+1. **Run full test suite**: `cd apps/backend && uv run pytest -v`
+2. **Lint**: `cd apps/frontend && npm run lint` (frontend unchanged but verify)
+3. **Manual smoke test** (optional):
+   - Start backend: `cd apps/backend && uv run uvicorn app.main:app --reload --port 8000`
+   - Check `GET http://localhost:8000/.well-known/oauth-protected-resource`
+   - Check `GET http://localhost:8000/.well-known/jwks.json`
+   - Check `GET http://localhost:8000/.well-known/oauth-authorization-server` (should have `registration_endpoint` and `jwks_uri`)
+   - POST to `http://localhost:8000/api/v1/oauth/register` with `{"redirect_uris": ["http://localhost:9999/callback"]}`
+   - POST to `http://localhost:8000/mcp` with `{"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {"protocolVersion": "2025-06-18", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}}`
+4. **Create PR** against `fork/main`
+
+---
+
+## Files Changed Summary
+
+| Action | File |
+|--------|------|
+| Create | `apps/backend/app/auth/keys.py` |
+| Modify | `apps/backend/app/auth/jwt.py` |
+| Modify | `apps/backend/app/auth/dependencies.py` |
+| Modify | `apps/backend/app/config.py` |
+| Modify | `apps/backend/app/models.py` |
+| Modify | `apps/backend/app/database.py` |
+| Modify | `apps/backend/app/routers/oauth.py` |
+| Modify | `apps/backend/app/main.py` |
+| Modify | `apps/backend/app/routers/__init__.py` |
+| Modify | `apps/backend/app/schemas/auth.py` |
+| Create | `apps/backend/app/routers/mcp.py` |
+| Create | `apps/backend/alembic/versions/*_add_oauth_clients_table.py` |
+| Modify | `apps/backend/tests/conftest.py` |
+| Create | `apps/backend/tests/unit/test_rsa_keys.py` |
+| Create | `apps/backend/tests/unit/test_jwt_rs256.py` |
+| Create | `apps/backend/tests/unit/test_oauth_clients_db.py` |
+| Create | `apps/backend/tests/integration/test_well_known_endpoints.py` |
+| Create | `apps/backend/tests/integration/test_dcr.py` |
+| Create | `apps/backend/tests/integration/test_claude_compat.py` |
+| Create | `apps/backend/tests/integration/test_mcp.py` |


### PR DESCRIPTION
## Summary

- **RS256 JWT migration**: Replaced HS256 symmetric signing with RS256 asymmetric key pair. Auto-generates 2048-bit RSA key on first startup, persists to `data/jwt_rsa_private.pem` with 0600 permissions.
- **JWKS endpoint** (`GET /.well-known/jwks.json`): Exposes RS256 public key for token verification (RFC 7517).
- **Protected Resource Metadata** (`GET /.well-known/oauth-protected-resource`): RFC 9728 endpoint for MCP client discovery.
- **Dynamic Client Registration** (`POST /api/v1/oauth/register`): RFC 7591 endpoint. Defaults `token_endpoint_auth_method` to `"none"` when omitted (claude.ai quirk).
- **OAuthClient model + migration**: DB-backed client validation replaces hardcoded constant. First-party client seeded via Alembic migration.
- **claude.ai compatibility proxies**: Root-level `/authorize`, `/token`, `/register` endpoints for claude.ai web (which ignores AS metadata URLs).
- **MCP endpoint** (`POST /mcp`): JSON-RPC 2.0 handler with 5 tools: `list_resumes`, `get_resume`, `get_status`, `upload_job_description`, `set_master_resume`. Auth required for `tools/list` and `tools/call`; `initialize` works without auth.

## Test plan

- [ ] `GET /.well-known/jwks.json` returns RS256 public key with no private components
- [ ] `GET /.well-known/oauth-protected-resource` returns valid RFC 9728 metadata
- [ ] `POST /api/v1/oauth/register` creates client and returns client_id
- [ ] `POST /mcp` with `initialize` works without Bearer token
- [ ] 338 tests pass (296 M4 baseline + 42 new)
- [ ] `POST /mcp` with `tools/list` requires Bearer token
- [ ] `POST /mcp` with `tools/call` respects user-scoped data isolation
- [ ] claude.ai compat: `POST /register` at root proxies to DCR endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RS256 JWT + JWKS support, Dynamic Client Registration (RFC 7591) with DB-backed OAuth clients, root-level compatibility proxies for claude.ai, MCP JSON‑RPC endpoint, and per-user data scoping with auth-required endpoints; frontend switched to authFetch and new rewrites.

* **Documentation**
  * Added design/implementation plans for OAuth/MCP, Google Sign‑in, and multi-user data isolation.

* **Tests**
  * New unit & integration tests covering RSA/JWT/JWKS, DCR, well-known endpoints, MCP, claude compatibility, and per-user isolation.

* **Chores**
  * .claude/worktrees/ added to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->